### PR TITLE
refactor: shared SupportDialog, remove Settings donation card

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { Menu, X, LogOut, ChevronDown, Coffee, Search, BookOpen } from 'lucide-react'
 import { track } from '@vercel/analytics'
 import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
+import { SupportDialog } from './SupportDialog'
 import { AVAILABLE_MODULES, DEFAULT_MODULE, SETTINGS_KEYS } from '@/lib/constants'
 import { useTranslation } from '@/lib/i18n'
 import type { User } from '@supabase/supabase-js'
@@ -14,9 +14,6 @@ interface HeaderProps {
   onToggleMenu: () => void
   onSignOut: () => void
 }
-
-// Hardcoded — not in i18n translations to reduce exposure if site is compromised
-const MOBILEPAY_NUMBER = ['+45', '5272', '8520'].join(' ')
 
 export function Header({ user, menuOpen, onToggleMenu, onSignOut }: HeaderProps) {
   const { locale, setLocale, t } = useTranslation()
@@ -148,23 +145,7 @@ export function Header({ user, menuOpen, onToggleMenu, onSignOut }: HeaderProps)
         )}
       </div>
 
-      <Dialog open={supportOpen} onOpenChange={setSupportOpen}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Coffee className="h-5 w-5 text-pink-500" />
-              {t('support.dialogTitle')}
-            </DialogTitle>
-            <DialogDescription>{t('support.dialogDesc')}</DialogDescription>
-          </DialogHeader>
-          <div className="flex flex-col items-center gap-3 py-2">
-            <div className="rounded-lg border-2 border-pink-200 dark:border-pink-800 bg-pink-50 dark:bg-pink-950 px-6 py-3">
-              <p className="text-2xl font-bold tracking-wider text-center select-all">{MOBILEPAY_NUMBER}</p>
-            </div>
-            <p className="text-xs text-muted-foreground text-center">{t('support.thankYou')}</p>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <SupportDialog open={supportOpen} onOpenChange={setSupportOpen} />
     </header>
   )
 }

--- a/src/components/layout/SupportDialog.tsx
+++ b/src/components/layout/SupportDialog.tsx
@@ -1,0 +1,35 @@
+import { Coffee } from 'lucide-react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
+import { useTranslation } from '@/lib/i18n'
+
+// Hardcoded — not in i18n translations to reduce exposure if site is compromised
+const MOBILEPAY_NUMBER = ['+45', '5272', '8520'].join(' ')
+
+interface SupportDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function SupportDialog({ open, onOpenChange }: SupportDialogProps) {
+  const { t } = useTranslation()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Coffee className="h-5 w-5 text-pink-500" />
+            {t('support.dialogTitle')}
+          </DialogTitle>
+          <DialogDescription>{t('support.dialogDesc')}</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col items-center gap-3 py-2">
+          <div className="rounded-lg border-2 border-pink-200 dark:border-pink-800 bg-pink-50 dark:bg-pink-950 px-6 py-3">
+            <p className="text-2xl font-bold tracking-wider text-center select-all">{MOBILEPAY_NUMBER}</p>
+          </div>
+          <p className="text-xs text-muted-foreground text-center">{t('support.thankYou')}</p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/data/translations/da.ts
+++ b/src/data/translations/da.ts
@@ -223,7 +223,7 @@ const da: Record<TranslationKeys, string> = {
 
   // Support / Donate
   'support.title': 'Støt',
-  'support.dialogTitle': 'Køb os en kaffe',
+  'support.dialogTitle': 'Køb udvikleren en kaffe',
   'support.dialogDesc': 'DanskPrep er gratis og open source. Hvis det hjælper din eksamensforberedelse, kan du købe os en kaffe via MobilePay:',
   'support.thankYou': 'Hver kaffe hjælper med at holde DanskPrep gratis og i udvikling. Tak!',
   'donate.support': 'Støt med MobilePay',

--- a/src/data/translations/en.ts
+++ b/src/data/translations/en.ts
@@ -221,7 +221,7 @@ const en = {
 
   // Support / Donate
   'support.title': 'Support',
-  'support.dialogTitle': 'Buy us a coffee',
+  'support.dialogTitle': 'Buy the developer a coffee',
   'support.dialogDesc': 'DanskPrep is free and open-source. If it helps your exam prep, consider buying us a coffee via MobilePay:',
   'support.thankYou': 'Every coffee helps keep DanskPrep free and improving. Tak!',
   'donate.support': 'Support with MobilePay',

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useAuth } from '@/hooks/useAuth'
 import { useProgress } from '@/hooks/useProgress'
 import { PageContainer } from '@/components/layout/PageContainer'
+import { SupportDialog } from '@/components/layout/SupportDialog'
 import { Dashboard } from '@/components/progress/Dashboard'
 import { WhatsNew } from '@/components/progress/WhatsNew'
 import { useTranslation } from '@/lib/i18n'
@@ -16,6 +17,7 @@ export function HomePage() {
   const [milestoneDismissed, setMilestoneDismissed] = useState(
     () => localStorage.getItem(MILESTONE_DISMISSED_KEY) === 'true'
   )
+  const [supportOpen, setSupportOpen] = useState(false)
 
   const dueCount = stats.learning + stats.review + stats.relearning
   const showMilestone = !milestoneDismissed && (stats.streakDays >= 7 || stats.total >= 100)
@@ -42,14 +44,12 @@ export function HomePage() {
             <Heart className="h-5 w-5 text-pink-500 shrink-0 mt-0.5" />
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium">{t('donate.milestone')}</p>
-              <a
-                href="https://www.mobilepay.dk/erhverv/betalingslink/betalingslink-LandingPage?phone=4552728520"
-                target="_blank"
-                rel="noopener noreferrer"
+              <button
+                onClick={() => setSupportOpen(true)}
                 className="inline-flex items-center gap-1.5 mt-2 rounded-md bg-[#5a78ff] px-3 py-1.5 text-xs font-medium text-white hover:bg-[#4a68ef] transition-colors"
               >
                 {t('donate.milestoneAction')}
-              </a>
+              </button>
             </div>
             <button
               onClick={dismissMilestone}
@@ -72,6 +72,7 @@ export function HomePage() {
         accuracyPercent={stats.accuracyPercent}
         isLoading={isLoading}
       />
+      <SupportDialog open={supportOpen} onOpenChange={setSupportOpen} />
     </PageContainer>
   )
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -7,7 +7,7 @@ import { SETTINGS_KEYS, DAILY_NEW_CARDS_LIMIT } from '@/lib/constants'
 import type { AIProvider } from '@/lib/ai-provider'
 import { getProviderConfig, saveProviderConfig, testOllamaConnection } from '@/lib/ai-provider'
 import { useTranslation } from '@/lib/i18n'
-import { Heart, AlertTriangle } from 'lucide-react'
+import { AlertTriangle } from 'lucide-react'
 
 export function SettingsPage() {
   const { t } = useTranslation()
@@ -311,31 +311,6 @@ export function SettingsPage() {
           {t('settings.moduleNote')}
         </p>
 
-        {/* Donation card */}
-        <Card className="border-dashed">
-          <CardContent className="pt-4 pb-4">
-            <div className="flex items-start gap-3">
-              <Heart className="h-5 w-5 text-pink-500 shrink-0 mt-0.5" />
-              <div>
-                <p className="text-sm font-medium">{t('donate.title')}</p>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {t('donate.description')}
-                </p>
-                <div className="mt-2 flex items-center gap-3">
-                  <span className="font-mono text-sm font-medium">{t('donate.mobilepayNumber')}</span>
-                  <a
-                    href="https://www.mobilepay.dk/erhverv/betalingslink/betalingslink-LandingPage?phone=4552728520"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 rounded-md bg-[#5a78ff] px-3 py-1.5 text-xs font-medium text-white hover:bg-[#4a68ef] transition-colors"
-                  >
-                    {t('donate.button')}
-                  </a>
-                </div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
       </div>
     </PageContainer>
   )


### PR DESCRIPTION
## Summary
- Extract `SupportDialog` into shared component (`src/components/layout/SupportDialog.tsx`)
- Header coffee button and HomePage milestone button both open the same dialog
- Remove donation card from SettingsPage
- Rename "Buy us a coffee" → "Buy the developer a coffee" (EN + DA)

## Test plan
- [ ] Header coffee icon opens support dialog with MobilePay number
- [ ] HomePage milestone card "Support with MobilePay" button opens same dialog
- [ ] Settings page no longer shows donation card
- [ ] Dialog title reads "Buy the developer a coffee"

🤖 Generated with [Claude Code](https://claude.com/claude-code)