### PR TITLE
chore: bump version to v0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "danskprep",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "danskprep",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@supabase/supabase-js": "^2.45.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "danskprep",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/data/seed/changelog.json
+++ b/src/data/seed/changelog.json
@@ -1,5 +1,26 @@
 [
   {
+    "version": "0.4.1",
+    "date": "2026-03-02",
+    "title": "Mobile Responsiveness & Quiz Fixes",
+    "highlights": [
+      "Mobile-first layouts: game panel overlay, responsive hero, 44px touch targets",
+      "Header no longer clips on small screens (375px+)",
+      "Dictionary page search input visible on mobile",
+      "Quiz multiple choice: fixed stale options bug between same-question exercises",
+      "Added 'Don't know — show answer' button to multiple choice questions",
+      "Added 'Bug report' category to exercise feedback dialog",
+      "CardRating 2x2 grid on mobile, DanishInput 44px keyboard buttons"
+    ],
+    "stats": {
+      "exercises": 292,
+      "words": 277,
+      "grammar_topics": 6,
+      "writing_prompts": 10,
+      "speaking_prompts": 8
+    }
+  },
+  {
     "version": "0.4.0",
     "date": "2026-03-02",
     "title": "Guest Mode & Welcome Page",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '0.4.0'
+export const APP_VERSION = '0.4.1'
 
 // Feature flags
 export const FEATURES = {


### PR DESCRIPTION
## Summary

- Bump `package.json`, `constants.ts`, `package-lock.json` version to `0.4.1`
- Add changelog entry for v0.4.1 (mobile responsiveness, quiz MC fix, report categories, dictionary mobile search)

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — passes
- [x] `npm run test` — 82/82 pass
- [ ] Verify Updates page shows v0.4.1 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)