### PR TITLE
fix: floating word bubbles blocking clicks on quiz buttons

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -66,8 +66,8 @@ export function Layout() {
           <Sidebar user={user} onClose={() => setMenuOpen(false)} />
         </aside>
 
-        {/* Main content */}
-        <div className="flex-1 min-w-0">
+        {/* Main content — z-20 to stack above z-10 floating bubbles */}
+        <div className="flex-1 min-w-0 relative z-20">
           <Outlet />
         </div>
 


### PR DESCRIPTION
## Summary

- Root cause: `FloatingWords` renders a `fixed inset-0 z-10` layer with `WordBubble` elements that have `pointer-events-auto`. When a bubble floats over a quiz button, it intercepts the click.
- Fix: add `relative z-20` to the main content area in `Layout.tsx` so all page content stacks above the `z-10` bubble layer.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — passes
- [x] `npm run test` — 82/82 pass
- [ ] Start a quiz with bubbles enabled → click multiple choice options → should work
- [ ] Click "Don't know — show answer" → should work
- [ ] Bubbles should still be visible behind content and clickable in empty areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)