### PR TITLE
fix: floating word bubbles blocking clicks on content

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -81,9 +81,10 @@ export function Layout() {
         />
       </div>
 
-      {/* Floating word bubbles — background layer */}
+      {/* Floating word bubbles — decorative background, non-interactive in Layout
+           so bubbles never block clicks on content (quiz buttons, etc.) */}
       {bubblesEnabled && (
-        <FloatingWords score={bubbleScore} onScoreChange={setBubbleScore} />
+        <FloatingWords score={bubbleScore} onScoreChange={setBubbleScore} interactive={false} />
       )}
 
       {/* Floating chat */}

--- a/src/components/welcome/FloatingWords.tsx
+++ b/src/components/welcome/FloatingWords.tsx
@@ -75,9 +75,11 @@ function useReducedMotion(): boolean {
 interface FloatingWordsProps {
   score?: number
   onScoreChange?: (count: number) => void
+  /** When false, bubbles are purely decorative and don't capture clicks */
+  interactive?: boolean
 }
 
-export function FloatingWords({ score = 0, onScoreChange }: FloatingWordsProps) {
+export function FloatingWords({ score = 0, onScoreChange, interactive = true }: FloatingWordsProps) {
   const reducedMotion = useReducedMotion()
   const [bubbles, setBubbles] = useState<ActiveBubble[]>([])
   const discoveredCountRef = useRef(score)
@@ -162,6 +164,7 @@ export function FloatingWords({ score = 0, onScoreChange }: FloatingWordsProps) 
           sway={bubble.sway}
           size={bubble.size}
           colorClasses={bubble.colorClasses}
+          interactive={interactive}
           onComplete={() => handleComplete(bubble.id)}
           onDiscover={handleDiscover}
         />

--- a/src/components/welcome/WordBubble.tsx
+++ b/src/components/welcome/WordBubble.tsx
@@ -24,6 +24,7 @@ interface WordBubbleProps {
   sway: number        // px, horizontal sway amplitude
   size: 'sm' | 'md' | 'lg'
   colorClasses?: BubbleColorClasses
+  interactive?: boolean // whether bubble captures pointer events (default true)
   onComplete: () => void
   onDiscover: () => void
 }
@@ -42,6 +43,7 @@ export function WordBubble({
   sway,
   size,
   colorClasses,
+  interactive = true,
   onComplete,
   onDiscover,
 }: WordBubbleProps) {
@@ -83,7 +85,8 @@ export function WordBubble({
       tabIndex={-1}
       onClick={handleClick}
       className={cn(
-        'absolute rounded-full border cursor-pointer select-none whitespace-nowrap transition-colors pointer-events-auto',
+        'absolute rounded-full border select-none whitespace-nowrap transition-colors',
+        interactive ? 'cursor-pointer pointer-events-auto' : 'pointer-events-none',
         SIZE_CLASSES[size],
         flipped
           ? 'ring-2 ring-green-400/50 bg-green-50/80 dark:bg-green-950/40 border-green-300/50 dark:border-green-700/50'


### PR DESCRIPTION
## Summary

- The previous z-index approach (`relative z-20` on content div) did not reliably prevent `pointer-events-auto` on floating WordBubble elements from intercepting clicks on quiz buttons and other interactive content
- Root fix: added `interactive` prop to `FloatingWords` and `WordBubble` components
  - **Layout**: passes `interactive={false}` — bubbles are purely decorative with `pointer-events-none`, never block content clicks
  - **WelcomePage**: keeps default `interactive={true}` — bubbles remain clickable for the word game

## Test plan

- [ ] Open `/quiz`, select a topic and start a quiz
- [ ] Verify multiple choice options and "Don't know" button respond to clicks
- [ ] Verify floating word bubbles still animate in the background
- [ ] Open `/welcome` — verify bubbles are still clickable there
- [ ] Run `npx tsc --noEmit` and `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)