### PR TITLE
docs: update landing URL to /welcome, add unused imports rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,10 @@ feature branch → PR → CI/CD → Claude review → human merge
 - Use `/pull-request` skill before creating PRs
 - Commit messages: explain *why*, not *what*
 
+## Strict TypeScript — Unused Imports
+
+`noUnusedLocals: true` is enabled. **When editing a file, always check whether the change makes any existing imports unused and remove them in the same edit.** Do not leave cleanup for a separate step — unused imports fail `tsc --noEmit` and CI. Common cases: removing a function call that was the only use of an import, replacing a component with a different one, extracting logic to a hook.
+
 ## Key Design Principles
 
 1. **Exam-focused only** — Every feature maps to an exam topic

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Active recall, spaced repetition (FSRS), and exam-focused exercises for learners preparing for the Danish integration language tests (Prøve i Dansk / Studieprøven).
 
-**Live app:** [danskprep.vercel.app](https://danskprep.vercel.app)
+**Live app:** [danskprep.vercel.app/welcome](https://danskprep.vercel.app/welcome)
 **GitHub:** [github.com/YanCheng-go/danskprep](https://github.com/YanCheng-go/danskprep)
 
 ## Features


### PR DESCRIPTION
## Summary

- Updated README live app link to `https://danskprep.vercel.app/welcome`
- Updated GitHub repo homepage URL to match
- Added strict TypeScript unused imports rule to CLAUDE.md — imports must be cleaned up in the same edit, not as a follow-up step

## Test plan

- [ ] Docs-only change — no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)