### PR TITLE
docs: add doc-update step to /commit skill, update README for v0.5.0

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -73,7 +73,23 @@ Fix errors on the same branch → commit → push → re-verify (`tsc --noEmit &
 3. `git checkout main && git pull --rebase`
 4. `git branch -d <branch>` — delete the local branch to keep the workspace clean
 
-## Step 6 — Update backlog
+## Step 6 — Update documentation
+
+**As the very last step before merge**, review and update all relevant docs in the same PR branch. Commit doc updates separately from code changes.
+
+Checklist — update each file **only if the PR makes it stale**:
+
+| Doc | When to update |
+|-----|---------------|
+| `README.md` | Content counts (words, exercises), Roadmap checkboxes, Features list, Python Scripts, Stack |
+| `NOTES.md` | Check off completed items, remove stale todos, update Known Issues |
+| `CLAUDE.md` | New conventions, changed directory structure, new exercise types, new env vars |
+| `src/data/seed/changelog.json` | Every user-visible change — add new version entry at top |
+| `docs/backlog.md` | Mark related BL-NNN items as `done`, update header counts |
+
+**Do not update a doc if the PR doesn't affect it.** Only touch what's stale.
+
+## Step 7 — Update backlog
 
 If PR relates to a backlog item: update `docs/backlog.md` status (`done` or add note), update header counts.
 
@@ -85,4 +101,4 @@ If PR relates to a backlog item: update `docs/backlog.md` status (`done` or add 
 - **Never skip CI** — wait for checks before merge
 - **Clean up unused imports** in the same edit
 - **One concern per commit** — separate unrelated changes
-- **Docs check**: update README roadmap/commands/stack when user-facing changes ship
+- **Docs last**: update docs as the final commit on the branch, after all code is done

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Active recall, spaced repetition (FSRS), and exam-focused exercises for learners
 - **Quiz** — 292 exercises across 7 types (cloze, multiple choice, word order, error correction, conjugation, type answer, matching)
 - **Vocabulary Drill** — bidirectional translation, context cloze, paradigm fill, form choice
 - **Grammar** — 6 topic reference pages with rules, examples, and practice links
-- **Vocabulary** — 277 words with inflection tables, search and filter
+- **Vocabulary** — 376 words with inflection tables, search and filter
 - **Writing** — exam-style prompts with AI scoring
 - **Speaking** — record, self-transcribe, AI grammar feedback
 - **Listening** — podcast episodes with comprehension quizzes and vocabulary highlights
@@ -101,6 +101,12 @@ uv run python scrape-speakspeak.py --exam PD3M2 --cookies cookies.json
 
 # Enrich vocabulary with AI-generated inflections (requires ANTHROPIC_API_KEY)
 uv run python enrich-vocabulary.py
+
+# Enrich verb inflections via local Ollama (no API key needed)
+uv run python enrich-via-ollama.py
+
+# Verify exercise answers and hints
+uv run python verify-exercises.py
 ```
 
 ## Content
@@ -108,7 +114,7 @@ uv run python enrich-vocabulary.py
 | Dataset | File | Count |
 |---------|------|-------|
 | Exercises | `exercises-pd3m2.json` | 292 |
-| Vocabulary | `words-pd3m2.json` | 277 |
+| Vocabulary | `words-pd3m2.json` | 376 |
 | Grammar topics | `grammar-pd3m2.json` | 6 |
 | Writing prompts | `writing-prompts-pd3m2.json` | 10 |
 | Speaking prompts | `speaking-prompts-pd3m2.json` | 8 |
@@ -193,7 +199,7 @@ All agent definitions live in `.claude/agents/`, skills in `.claude/skills/`. Re
 ### Next
 - [ ] Generate real DB types (`npm run types` → replace `createClient<any>()`)
 - [ ] Seed remote database (`cd scripts && uv run python seed-database.py`)
-- [ ] Fill 143 empty verb inflections (run `enrich-vocabulary.py`)
+- [x] Fill verb inflections (376 words, 222 verbs with complete conjugations)
 - [ ] Refresh progress stats after study session
 - [ ] WordOrder drag-and-drop reorder
 - [ ] Lazy-load seed JSON (reduce initial bundle)


### PR DESCRIPTION
## Summary
- Added Step 6 (Update documentation) to `/commit` skill with a checklist of 5 docs and when to update each
- Renumbered old Step 6 (backlog) to Step 7
- Updated README.md: vocabulary count 277→376, added new scripts (enrich-via-ollama.py, verify-exercises.py), checked off verb inflections roadmap item

## Backlog
- None

## Docs updated
- [x] README.md (content counts, scripts, roadmap checkbox)
- [x] `.claude/skills/commit/SKILL.md` (new Step 6 doc-update checklist)

## Test plan
- [x] No code changes — docs only
- [x] Manually verified: commit skill has correct step numbering and doc table

🤖 Generated with [Claude Code](https://claude.com/claude-code)