### PR TITLE
fix: refactor shipping skills, add human checkpoints, sync v0.5.0

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -14,13 +14,11 @@ You are an autonomous coding agent for DanskPrep. You pick work from the backlog
     ↓
 Create feature branch → implement → test → fix
     ↓
-/commit → CHECKPOINT: PR ready for review
-    ↓
-Self-review → fix issues → re-test
+/commit → PR → self-review → fix → CHECKPOINT: approve merge
     ↓
 CHECKPOINT: release decision
     ↓ (if releasing)
-/release → version bump → merge
+/release → assess since last tag → changelog → release PR → CHECKPOINT: approve merge
     ↓
 /retro → update backlog → filter learnings
     ↓ (if notable release)
@@ -139,40 +137,23 @@ Also verify:
 
 ## Phase 5: Commit & PR
 
-1. Push the feature branch
-2. Run `/commit` to create the PR
-
-**CHECKPOINT — PR Ready**
-Present the PR to the user:
-```
-PR ready: <title>
-Branch: feature/<name>
-Changes: N files, +X/-Y lines
-Tests: N new, all passing
-
-Key changes:
-- <bullet 1>
-- <bullet 2>
-
-Ready for review?
-```
-Wait for user approval.
+1. Run `/commit` to create the PR — this will:
+   - Commit, create branch, push, open PR
+   - Self-review the diff
+   - Fix any issues found
+   - Present the PR summary and **STOP for user approval**
+2. Wait for user to approve the merge (or request fixes)
+3. Once approved, `/commit` merges the PR
 
 ---
 
-## Phase 6: Self-Review & Fix
+## Phase 6: Post-Merge Cleanup
 
-After creating the PR:
+After a PR is accepted and merged:
 
-1. Re-read every changed file as if you're a reviewer
-2. Check for:
-   - Logic errors or edge cases missed
-   - Performance concerns (unnecessary re-renders, large bundle imports)
-   - Security issues (unsanitized input, exposed secrets)
-   - Missing error handling
-   - Incomplete mobile/dark mode support
-3. If issues found, fix them and push additional commits
-4. Re-run the quality gate
+1. **Mark backlog item as done:** `/backlog done BL-NNN`
+2. **Delete plan doc (if any):** If a plan exists in `docs/plans/` for this item, delete it — the work is now implemented and the plan is obsolete
+3. **Unblock dependents:** Check if any other backlog items were waiting on this one and update their status if now unblocked
 
 ---
 
@@ -206,7 +187,7 @@ Release now?
 ```
 Wait for user approval.
 
-If releasing, run `/release` (which chains: changelog → build verify → PR → GitHub release).
+If releasing, run `/release` — this starts from `main`, assesses all changes since the last release tag, runs `/update-changelog`, creates a release branch + PR, and stops for user approval. CI auto-creates the GitHub release after merge.
 
 ---
 

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: commit
-description: Commit, PR, self-review, fix, merge — full ship cycle
+description: Commit, branch, PR, self-review, fix — then stop for human approval before merge
 user-invocable: true
 ---
 
 # /commit — Ship Cycle
 
-Commit → branch → PR → self-review → fix → CI → merge. **Never push directly to main.**
+Commit → branch → PR → self-review → fix → docs → **STOP for human approval** → merge. **Never push directly to main.**
 
 | Invocation | Behaviour |
 |---|---|
@@ -41,10 +41,6 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 ## Backlog
 - Relates to: BL-NNN (or "None")
 
-## Docs updated
-- [ ] README.md (if user-facing: roadmap, stack, commands)
-- [ ] NOTES.md (check off completed items)
-
 ## Test plan
 - [ ] `npx tsc --noEmit` + `npm run build` + `npx vitest run`
 - [ ] Manually verified: <description>
@@ -66,16 +62,9 @@ EOF
 
 Fix errors on the same branch → commit → push → re-verify (`tsc --noEmit && build && vitest run`).
 
-## Step 5 — CI and merge
+## Step 5 — Update documentation
 
-1. `gh pr checks <number>` — wait for CI to pass (fix failures if any)
-2. `gh pr merge <number> --squash --delete-branch` (deletes the remote branch)
-3. `git checkout main && git pull --rebase`
-4. `git branch -d <branch>` — delete the local branch to keep the workspace clean
-
-## Step 6 — Update documentation
-
-**As the very last step before merge**, review and update all relevant docs in the same PR branch. Commit doc updates separately from code changes.
+Review and update all relevant docs on the PR branch. Commit doc updates separately from code changes.
 
 Checklist — update each file **only if the PR makes it stale**:
 
@@ -84,21 +73,56 @@ Checklist — update each file **only if the PR makes it stale**:
 | `README.md` | Content counts (words, exercises), Roadmap checkboxes, Features list, Python Scripts, Stack |
 | `NOTES.md` | Check off completed items, remove stale todos, update Known Issues |
 | `CLAUDE.md` | New conventions, changed directory structure, new exercise types, new env vars |
-| `src/data/seed/changelog.json` | Every user-visible change — add new version entry at top |
 | `docs/backlog.md` | Mark related BL-NNN items as `done`, update header counts |
 
 **Do not update a doc if the PR doesn't affect it.** Only touch what's stale.
 
-## Step 7 — Update backlog
+## Step 6 — Human checkpoint ⛔
 
-If PR relates to a backlog item: update `docs/backlog.md` status (`done` or add note), update header counts.
+**STOP HERE.** Present the following summary to the user and wait for their decision:
+
+```
+## PR ready for review
+
+- PR: <PR URL>
+- Branch: <branch name>
+- Diff: +N / -N lines across M files
+- Self-review verdict: Clean / Needs fixes
+- CI status: <passing / pending / failing>
+
+Please review the PR. Reply with:
+- "merge" — to proceed with squash merge
+- "fix <issue>" — to address something before merge
+- or any other feedback
+```
+
+**Do NOT proceed to Step 7 unless the user explicitly approves the merge.**
+
+## Step 7 — Merge (only on user approval)
+
+1. `gh pr checks <number>` — confirm CI passes (fix failures if any)
+2. `gh pr merge <number> --squash --delete-branch` (deletes the remote branch)
+3. `git checkout main && git pull --rebase`
+4. `git branch -d <branch>` — delete the local branch to keep the workspace clean
+
+## Step 8 — Release reminder
+
+After merge, ask the user:
+
+```
+Merged to main. Want to cut a release?
+Run /release to assess changes since the last tag and create a release PR.
+```
+
+This is just a reminder — the user decides. Do not run `/release` automatically.
 
 ---
 
 ## Rules
 
 - **Never push to main** — always PR
+- **Never merge without user approval** — always stop at Step 6
 - **Never skip CI** — wait for checks before merge
 - **Clean up unused imports** in the same edit
 - **One concern per commit** — separate unrelated changes
-- **Docs last**: update docs as the final commit on the branch, after all code is done
+- **Docs before merge**: update docs as the final commit on the branch, before requesting review

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,21 +1,20 @@
 ---
 name: release
-description: Orchestrate a release — changelog, build verification, PR creation, and GitHub release notes
+description: Cut a versioned release — assess changes since last tag, changelog, version bump, release PR
 user-invocable: true
 ---
 
-# /release — Ship a Release
+# /release — Cut a Release
 
 ## When to use
 
-When a batch of work is ready to ship. This skill chains together the release checklist: update the changelog, verify the build, create a PR, and draft GitHub release notes.
+When multiple PRs have been merged to `main` and you're ready to cut a versioned release. This skill looks at everything since the last release tag, creates a changelog entry, bumps the version, and opens a small release PR.
 
 ## Prerequisites
 
-Before running this skill:
-- All feature work is committed on a feature branch (not `main`)
-- Tests pass locally
-- No uncommitted changes
+- You are on `main` with a clean working tree (`git status` shows no changes)
+- One or more PRs have been merged since the last release tag
+- `gh auth switch --user YanCheng-go` has been run
 
 If any prerequisite fails, stop and tell the user what needs fixing.
 
@@ -23,8 +22,15 @@ If any prerequisite fails, stop and tell the user what needs fixing.
 
 ### Step 1 — Assess what's being released
 
-1. Run `git log --oneline main..HEAD` to see all commits on this branch
-2. Run `git diff --stat main..HEAD` to see all files changed
+1. Find the last release tag:
+   ```bash
+   LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+   ```
+2. List changes since that tag (or all commits if no tag exists):
+   ```bash
+   git log --oneline ${LAST_TAG:+$LAST_TAG..HEAD}
+   git diff --stat ${LAST_TAG:+$LAST_TAG..HEAD}
+   ```
 3. Read `docs/backlog.md` to identify which backlog items are addressed
 4. Categorize changes:
    - **Features** — new user-facing functionality
@@ -35,28 +41,33 @@ If any prerequisite fails, stop and tell the user what needs fixing.
 
 Present the summary to the user and confirm this is what should be released.
 
-### Step 2 — Update changelog
+### Step 2 — Create release branch
 
-Run the `/update-changelog` skill logic:
+```bash
+git checkout -b release/vX.Y.Z
+```
 
-1. Read `src/data/seed/changelog.json`
-2. Determine version bump:
-   - **Patch** (0.0.x) — bug fixes only
-   - **Minor** (0.x.0) — new features or content
-   - **Major** (x.0.0) — breaking changes (rare)
-3. Count current content:
-   ```bash
-   python3 -c "import json; print(len(json.load(open('src/data/seed/exercises-pd3m2.json'))))"
-   python3 -c "import json; print(len(json.load(open('src/data/seed/words-pd3m2.json'))))"
-   ```
-4. Write the new changelog entry at the TOP of the array
-5. Sync version in all three places:
-   - `src/data/seed/changelog.json` → latest entry `version`
-   - `src/lib/constants.ts` → `APP_VERSION`
-   - `package.json` → `version`
-6. Confirm the version bump with the user before writing
+### Step 3 — Update changelog and version
 
-### Step 3 — Verify build
+Run `/update-changelog` to create the changelog entry, bump the version, and sync all three locations (changelog.json, constants.ts, package.json).
+
+Pass the last release tag so it knows the correct range of changes to summarize.
+
+Confirm the version bump with the user before writing.
+
+### Step 4 — Update documentation
+
+Checklist — update each file **only if changes since last release make it stale**:
+
+| Doc | When to update |
+|-----|---------------|
+| `README.md` | Content counts, Roadmap checkboxes, Features list, Stack |
+| `NOTES.md` | Check off completed items, remove stale todos |
+| `docs/backlog.md` | Mark related BL-NNN items as `done`, update header counts |
+
+**Do not update a doc if the release doesn't affect it.**
+
+### Step 5 — Verify build
 
 Run all checks — stop if any fail:
 
@@ -67,38 +78,31 @@ npm test                  # All tests pass
 npm run build             # Production build succeeds
 ```
 
-If a check fails, fix the issue and re-run. Do not proceed to PR creation with failing checks.
+If a check fails, fix the issue and re-run. Do not proceed with a broken build.
 
-### Step 4 — Update documentation
-
-Follow the `/commit` skill's documentation checklist:
-
-1. **NOTES.md** — add session log entry under Completed, check off done items
-2. **docs/backlog.md** — mark completed items as done via `/backlog done BL-NNN`
-3. **README.md** — update if roadmap, commands, or stack changed
-
-### Step 5 — Commit release changes
-
-Stage and commit the changelog + version bump + documentation updates:
+### Step 6 — Commit and push
 
 ```bash
-git add src/data/seed/changelog.json src/lib/constants.ts package.json NOTES.md docs/backlog.md README.md
+git add src/data/seed/changelog.json src/lib/constants.ts package.json
+# Also stage any docs that were actually updated:
+# git add README.md NOTES.md docs/backlog.md
 git commit -m "$(cat <<'EOF'
-chore: bump version to X.Y.Z, update changelog
+chore: release vX.Y.Z
 
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 EOF
 )"
+git push -u origin release/vX.Y.Z
 ```
 
 Only stage files that were actually modified. Do not use `git add -A`.
 
-### Step 6 — Create the PR
+### Step 7 — Create the PR
 
 ```bash
 gh pr create --title "release: vX.Y.Z — <short description>" --body "$(cat <<'EOF'
 ## Summary
-- <3-5 bullet points of user-facing changes>
+- <3-5 bullet points summarizing changes since last release>
 
 ## Release checklist
 - [x] Changelog updated (`src/data/seed/changelog.json`)
@@ -106,8 +110,6 @@ gh pr create --title "release: vX.Y.Z — <short description>" --body "$(cat <<'
 - [x] `npx tsc --noEmit` passes
 - [x] `npm test` passes
 - [x] `npm run build` succeeds
-- [x] NOTES.md session log updated
-- [x] Backlog items marked done
 
 ## Content stats
 - Exercises: N
@@ -119,57 +121,52 @@ EOF
 )"
 ```
 
-### Step 7 — Draft GitHub release notes
+### Step 8 — Human checkpoint ⛔
 
-After the PR is created, prepare release notes for after merge:
+**STOP HERE.** Present the summary and wait for the user to decide:
 
-```bash
-gh release create vX.Y.Z --draft --title "vX.Y.Z — <short description>" --notes "$(cat <<'EOF'
-## What's New
-
-- <user-facing highlights, 3-8 bullets>
-
-## Content
-- N exercises, N words, N grammar topics
-
-## Full Changelog
-https://github.com/YanCheng-go/danskprep/compare/vPREV...vX.Y.Z
-EOF
-)"
 ```
-
-Tell the user: "Draft release created. After merging the PR, publish the release from GitHub."
-
-### Step 8 — Final summary
-
-Output:
-```
-## Release vX.Y.Z ready
+## Release vX.Y.Z ready for review
 
 - PR: <PR URL>
-- Draft release: <release URL>
+- Branch: release/vX.Y.Z
 - Version: X.Y.Z (synced in 3 places)
+- Changes since last release: N commits across M PRs
 - Changelog: N highlights
-- Backlog items closed: BL-NNN, BL-NNN
 
-Next: merge the PR, then publish the draft release on GitHub.
+Please review the PR. Reply with:
+- "merge" — to squash-merge (CI will auto-create the GitHub release)
+- "fix <issue>" — to address something first
 ```
+
+**Do NOT merge unless the user explicitly approves.**
+
+### Step 9 — Merge (only on user approval)
+
+1. `gh pr checks <number>` — confirm CI passes
+2. `gh pr merge <number> --squash --delete-branch`
+3. `git checkout main && git pull --rebase`
+4. `git branch -d release/vX.Y.Z`
+
+CI will auto-create the GitHub release from the version in `package.json`.
 
 ## Rules
 
 - Always confirm the version bump with the user before writing
-- Never skip the build verification step — failing builds must be fixed first
+- Never skip the build verification step
 - Always switch to the correct GitHub account first: `gh auth switch --user YanCheng-go`
 - Never force-push or push directly to main
-- The draft release is created but NOT published — the user publishes after merge
-- If there are no user-facing changes, skip the changelog and just create a maintenance PR
+- **Never merge without user approval** — always stop at Step 8
+- CI auto-creates the GitHub release after merge — no manual draft needed
+- If there are no user-facing changes, skip the changelog and create a maintenance PR instead
 - Co-author line on all commits: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
 
 ## Troubleshooting
 
 | Problem | Fix |
 |---|---|
+| No release tag exists yet | Use full git log; `/update-changelog` handles this gracefully |
 | `gh: not authenticated` | Run `gh auth switch --user YanCheng-go` |
 | Version mismatch between 3 files | Re-read all three, fix the one that's wrong |
 | Build fails on type errors | Run `npx tsc --noEmit` to see the errors, fix them |
-| PR creation fails | Check branch is pushed: `git push -u origin <branch>` |
+| PR creation fails | Check branch is pushed: `git push -u origin release/vX.Y.Z` |

--- a/.claude/skills/update-changelog/SKILL.md
+++ b/.claude/skills/update-changelog/SKILL.md
@@ -7,12 +7,17 @@ user-invocable: true
 # /update-changelog — Add a new changelog entry
 
 ## When to use
-After a batch of features/fixes are ready, before creating a PR. Summarizes the session's work into `src/data/seed/changelog.json`, bumps the version, and ensures the WhatsNew banner + GitHub Release will pick it up.
+Called by `/release` (or standalone) to summarize changes into `src/data/seed/changelog.json`, bump the version, and sync all three version locations.
 
 ## Steps
 
 1. **Read current changelog**: `src/data/seed/changelog.json`
-2. **Review recent git changes**: `git log --oneline -20` + `git diff --stat HEAD~10`
+2. **Review changes since last release**:
+   ```bash
+   LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+   git log --oneline ${LAST_TAG:+$LAST_TAG..HEAD}
+   ```
+   If no tag exists, review the full log: `git log --oneline -30`
 3. **Summarize highlights**: 3-8 bullet points describing user-facing changes
 4. **Determine version**: bump patch for fixes, minor for features, major for breaking
 5. **Count content**:
@@ -35,7 +40,6 @@ After a batch of features/fixes are ready, before creating a PR. Summarizes the 
    - `src/lib/constants.ts` → `APP_VERSION`
    - `package.json` → `version`
 8. **Verify**: `npx tsc --noEmit && npm run build`
-9. **Confirm** the Updates page renders correctly
 
 ## Rules
 - Date is always today's date

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Read version from package.json
         id: version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ feature branch → PR → CI/CD → Claude review → human merge
 
 - Never push directly to `main`
 - Never merge without passing CI + Claude review
-- Use `/commit` skill to ship changes (branch → PR → review → merge)
+- Use `/commit` skill to ship changes (branch → PR → review → STOP for approval → merge)
 - Commit messages: explain *why*, not *what*
 
 ## Strict TypeScript — Unused Imports
@@ -112,7 +112,7 @@ Never commit `.env.local`.
 | `/backlog` | Skill | Manage backlog items — add, list, filter, update, prioritize |
 | `/retro` | Skill | End-of-session retrospective, update backlog + session log |
 | `/scope` | Skill | Break a backlog item into sub-tasks with effort/risk |
-| `/release` | Skill | Changelog → build verify → PR → GitHub release |
+| `/release` | Skill | Cut a release — assess changes since last tag → changelog → version bump → release PR |
 | `/some` | Skill | Social media post generator (LinkedIn/Twitter/FB) |
 | `coder` | Agent | Autonomous dev cycle: pick item → code → test → PR → retro |
 | `pm` | Agent | Exam-aligned research, roadmap planning, feature breakdown |

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This project is built using an **AI-first development methodology** powered by [
 | **content-generator** | Agent | Danish exercise and grammar content generation |
 | `/backlog` | Skill | Manage backlog items — add, list, filter, update, prioritize |
 | `/scope` | Skill | Break a backlog item into sub-tasks with effort and risk |
-| `/release` | Skill | Changelog → build verify → PR → GitHub release |
+| `/release` | Skill | Cut a release — assess changes since last tag → changelog → version bump → release PR |
 | `/retro` | Skill | End-of-session retrospective, update backlog and session log |
 | `/some` | Skill | Social media post generator (LinkedIn, Twitter, Facebook) |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "danskprep",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "danskprep",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@supabase/supabase-js": "^2.45.0",
@@ -24,7 +24,9 @@
         "ts-fsrs": "^4.3.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.1",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.58.2",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.0.1",
@@ -86,6 +88,19 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1343,6 +1358,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -3802,6 +3833,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {
@@ -6266,6 +6307,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "danskprep",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -27,7 +27,9 @@
     "ts-fsrs": "^4.3.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.58.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '0.4.1'
+export const APP_VERSION = '0.5.0'
 
 // Feature flags
 export const FEATURES = {


### PR DESCRIPTION
## Summary
- **/commit**: add human checkpoint (Step 6) before merge, fix step ordering bug where docs came after merge, add release reminder after merge
- **/release**: rewrite for multi-PR flow — starts from `main`, assesses changes since last git tag, delegates changelog to `/update-changelog`
- **/update-changelog**: use `git describe --tags` range instead of hardcoded `HEAD~10`
- **release.yml**: add `fetch-tags: true` so CI tag existence check works
- **Version sync**: `0.4.1` → `0.5.0` in `package.json` + `constants.ts` (was out of sync with `changelog.json`)
- Update `CLAUDE.md`, `README.md`, `coder` agent to match new skill flow

## Backlog
- Relates to: None

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] Grepped for stale `0.4.1` — no project source references remain
- [x] Skill cross-references verified: no circular dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)