### PR TITLE
release: v0.6.0 — accessibility & developer experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "danskprep",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/data/seed/changelog.json
+++ b/src/data/seed/changelog.json
@@ -1,5 +1,27 @@
 [
   {
+    "version": "0.6.0",
+    "date": "2026-03-03",
+    "title": "Accessibility & Developer Experience",
+    "highlights": [
+      "Skip-to-content link for keyboard and screen reader navigation (BL-004)",
+      "Aria-labels on all icon buttons and search inputs (BL-027, BL-029)",
+      "Fixed mobile horizontal overflow on all Layout pages (BL-026)",
+      "Lazy-loaded Agentation component — excluded from production bundle (BL-008)",
+      "User-added exercises now appear immediately in quiz without page reload (BL-016)",
+      "Extracted shared shuffle utility, replacing 3 duplicate implementations (BL-012)",
+      "Migrated project backlog from docs/backlog.md to GitHub Projects",
+      "Added preposition and conjunction vocabulary filter translations"
+    ],
+    "stats": {
+      "exercises": 292,
+      "words": 376,
+      "grammar_topics": 6,
+      "writing_prompts": 10,
+      "speaking_prompts": 8
+    }
+  },
+  {
     "version": "0.5.0",
     "date": "2026-03-03",
     "title": "Enriched Vocabulary & Exercise Verification",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '0.5.0'
+export const APP_VERSION = '0.6.0'
 
 // Feature flags
 export const FEATURES = {


### PR DESCRIPTION
## Summary
- **Accessibility**: skip-to-content link, aria-labels on all icon buttons and search inputs, fixed mobile horizontal overflow (BL-004, BL-026, BL-027, BL-029)
- **Code quality**: lazy-load Agentation from prod bundle (BL-008), fix stale user exercises in quiz (BL-016), extract shared shuffle utility (BL-012)
- **Infrastructure**: migrated backlog from docs/backlog.md to GitHub Projects, updated 5 skills for `gh` CLI
- **i18n**: added preposition/conjunction vocabulary filter translations

## Release checklist
- [x] Changelog updated (`src/data/seed/changelog.json`)
- [x] Version synced (changelog, constants.ts, package.json)
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 91 tests pass
- [x] `npm run build` succeeds

## Content stats
- Exercises: 292
- Words: 376
- Grammar topics: 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)