### PR TITLE
fix: release workflow fails on non-release pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Read version from package.json
         id: version
@@ -23,10 +21,12 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Check if tag already exists
+      - name: Check if release already exists
         id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+          if gh release view "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Release workflow failed with `HTTP 422: Release.tag_name already exists` on every non-release push to main
- Root cause: `git rev-parse` checked local tags, but `actions/checkout` doesn't reliably fetch all tags — so the "tag exists" check returned false, then `gh release create` failed
- Fix: replaced `git rev-parse` with `gh release view` which checks GitHub directly

## Test plan
- [x] Non-release pushes to main should now skip silently (green check)
- [x] Release pushes (new version in package.json) still create a GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)