### PR TITLE
feat: add /daily and /weekly session workflow skills

### DIFF
--- a/.claude/skills/daily/SKILL.md
+++ b/.claude/skills/daily/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: daily
+description: Daily session wrapper — start with backlog, work, simplify, commit, retro
+user-invocable: true
+---
+
+# /daily — Daily Session Flow
+
+A guided checklist for a productive session. Run at the start of a work session — it walks you through the full cycle.
+
+| Invocation | Behaviour |
+|---|---|
+| `/daily` | Full session flow (start → work → ship → close) |
+| `/daily start` | Just the opening steps (1–2) — see what's ready and pick work |
+| `/daily wrap` | Just the closing steps (4–6) — simplify, commit, retro |
+
+---
+
+## Step 1 — Open: backlog dashboard
+
+Run `/backlog` (dashboard mode) to show:
+- Items currently In Progress
+- Top 5 ready items by priority
+- Any items blocked
+
+Present a quick summary:
+```
+## Today's Board
+🔵 In Progress: BL-012 (description), BL-018 (description)
+⬜ Ready (top 3): BL-025 (p1/s), BL-031 (p2/xs), BL-014 (p2/m)
+🔴 Blocked: none
+```
+
+## Step 2 — Pick work
+
+Ask the user what they want to work on today:
+1. **Continue** an in-progress item
+2. **Start** one of the ready items (suggest the top pick from `/backlog next` scoring)
+3. **Something else** — ad-hoc task (create a backlog item for it)
+
+Once decided, set the item to in-progress:
+```bash
+gh project item-edit --project-id PVT_kwHOAtALr84BQs_6 --id <item_id> \
+  --field-id PVTSSF_lAHOAtALr84BQs_6zg-vxHc --single-select-option-id 47fc9ee4
+```
+
+Then hand off to the user: "Ready to go. Work on the task, then run `/daily wrap` when you're done — or I'll remind you."
+
+**STOP HERE and let the user work.** Do not proceed to Step 3 automatically.
+
+---
+
+## Step 3 — Work (user does this)
+
+The user codes, tests, iterates. This step is implicit — the skill resumes at Step 4 when the user runs `/daily wrap` or asks to wrap up.
+
+---
+
+## Step 4 — Simplify
+
+Run `/simplify` on all changed files:
+1. `git diff --name-only` to find modified files
+2. Review for: dead code, unused imports, over-engineering, duplication, missing types
+3. Apply fixes if any
+4. `npx tsc --noEmit` to verify no type errors introduced
+
+If no changes were made, skip this step.
+
+## Step 5 — Commit
+
+Run `/commit` to ship changes:
+- Branch, PR, self-review, fix, docs update
+- Stops at human checkpoint for approval
+
+If no uncommitted changes exist, skip this step.
+
+## Step 6 — Retro
+
+Run `/retro` to close out:
+- Summarize what was done
+- Update backlog statuses (done, in-progress, new discoveries)
+- Append session log to NOTES.md
+- Suggest next session priorities
+
+---
+
+## Rules
+
+- Steps 1–2 run together at session start
+- Steps 4–6 run together at session end
+- Never skip the human checkpoint in `/commit` (Step 5)
+- If the user only runs `/daily start`, stop after Step 2
+- If the user only runs `/daily wrap`, start from Step 4
+- Keep the opening dashboard concise — no more than 10 lines

--- a/.claude/skills/weekly/SKILL.md
+++ b/.claude/skills/weekly/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: weekly
+description: Weekly review — prioritize backlog, review progress, release check, plan ahead
+user-invocable: true
+---
+
+# /weekly — Weekly Review
+
+Run once a week (ideally Monday) to review progress, clean up the backlog, and plan the week ahead.
+
+| Invocation | Behaviour |
+|---|---|
+| `/weekly` | Full weekly review (all steps) |
+| `/weekly review` | Steps 1–3 only — review and prioritize |
+| `/weekly plan` | Steps 4–5 only — release check and week plan |
+
+---
+
+## Step 1 — Week in review
+
+Gather what happened since last week:
+1. `git log --oneline --since="7 days ago"` — commits this week
+2. `gh pr list --repo YanCheng-go/danskprep --state merged --search "merged:>=$(date -v-7d +%Y-%m-%d)" --json title,number,mergedAt --limit 20` — merged PRs
+3. `gh issue list --repo YanCheng-go/danskprep --state closed --search "closed:>=$(date -v-7d +%Y-%m-%d)" --json title,number --limit 20` — closed issues
+
+Present a summary:
+```
+## Week of YYYY-MM-DD
+
+### Shipped
+- PR #42: BL-012 — Quiz timer feature
+- PR #43: BL-018 — Fix mobile layout
+
+### Closed
+- BL-012, BL-018, BL-025 (3 items completed)
+
+### Stats
+- Commits: N | PRs merged: N | Issues closed: N
+```
+
+## Step 2 — Backlog health check
+
+Fetch all open items and review:
+1. **Stale in-progress** — items marked In Progress for 7+ days without commits. Ask: still working on this, or should it go back to ready?
+2. **p3 accumulation** — if more than 10 p3 items exist, suggest dropping or promoting some
+3. **Idea review** — list all items with `status:idea` label. Ask: promote any to ready?
+4. **Missing metadata** — items without priority, effort, or scope set
+
+Present findings and ask the user for decisions on each.
+
+## Step 3 — Prioritize
+
+Run `/backlog prioritize` logic:
+1. Group open items by priority (p0 → p3)
+2. Within each priority, sort by effort (xs first for quick wins)
+3. Ask the user:
+   - Any items to promote (e.g., p3 → p2)?
+   - Any items to drop?
+   - Any new items to add?
+4. Apply changes as batch `gh project item-edit` calls
+
+## Step 4 — Release check
+
+Check if a release is warranted:
+1. `git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || echo HEAD~50)..HEAD` — changes since last tag
+2. Count: features, fixes, content additions
+3. If 3+ meaningful changes since last release, suggest: "Enough changes for a release. Run `/release`?"
+4. If not, note it: "Only N changes since last release — hold off."
+
+Do not run `/release` automatically — just recommend.
+
+## Step 5 — Plan the week
+
+Based on the current backlog state, suggest a week plan:
+1. **Must do** — any p0/p1 items (list them)
+2. **Should do** — top 3 p2 items by effort (quick wins first)
+3. **Could do** — 1-2 p3 items if time allows
+4. **Blocked** — items that need something unblocked first
+
+Present as a simple plan:
+```
+## This Week's Plan
+
+### Must
+- BL-005: Fix auth token refresh (p1/s)
+
+### Should
+- BL-031: Add cloze hint translations (p2/xs)
+- BL-014: Lazy-load seed JSON (p2/m)
+- BL-028: Progress page refresh (p2/s)
+
+### Could
+- BL-033: Dark mode polish (p3/xs)
+
+### Blocked
+- BL-019: Listening exercises — needs audio scraper update
+```
+
+---
+
+## Rules
+
+- This is a review session — never auto-commit, auto-merge, or auto-release
+- Always confirm before making batch backlog changes
+- Keep summaries concise — tables and bullet points, not paragraphs
+- If the user runs `/weekly review`, stop after Step 3
+- If the user runs `/weekly plan`, start from Step 4
+- Use today's date for all timestamps


### PR DESCRIPTION
## Summary
- Add `/daily` skill: guided session wrapper (backlog → pick work → simplify → commit → retro) with `/daily start` and `/daily wrap` subcommands
- Add `/weekly` skill: weekly review cadence (recap → backlog health → prioritize → release check → week plan) with `/weekly review` and `/weekly plan` subcommands
- Both skills chain existing skills together rather than duplicating logic

## Backlog
- None (ad-hoc workflow improvement)

## Test plan
- [ ] Skills are correctly detected by Claude Code (appear in skill list)
- [ ] `/daily start` shows backlog dashboard and prompts for work selection
- [ ] `/daily wrap` runs simplify → commit → retro sequence
- [ ] `/weekly` runs full review flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)