### PR TITLE
chore: centralize backlog status updates through /backlog skill

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -36,8 +36,12 @@ git checkout main && git pull --rebase origin main && git branch -d <stale-branc
 
 1. `git status` + `git diff --stat HEAD` to see what changed
 2. Check GitHub Issues for related backlog items: `gh issue list --repo YanCheng-go/danskprep --search "<keywords>" --state open --json number,title --limit 5`
-3. Stage specific files (`git add <files>` — never `-A`; skip `.env`, secrets, unrelated changes)
-4. Commit: imperative message, under 70 chars, explains *why*. End with `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+3. **Update backlog status** — if a matching backlog item is found:
+   - If it's **Todo**, set it to **In Progress** via `/backlog update BL-NNN status=in-progress`
+   - If the PR will fully complete it, note the issue number for `Closes #NNN` in Step 2
+   - If no matching item found, skip this step
+4. Stage specific files (`git add <files>` — never `-A`; skip `.env`, secrets, unrelated changes)
+5. Commit: imperative message, under 70 chars, explains *why*. End with `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
 
 ## Step 2 — Branch and PR
 

--- a/.claude/skills/daily/SKILL.md
+++ b/.claude/skills/daily/SKILL.md
@@ -38,11 +38,7 @@ Ask the user what they want to work on today:
 2. **Start** one of the ready items (suggest the top pick from `/backlog next` scoring)
 3. **Something else** — ad-hoc task (create a backlog item for it)
 
-Once decided, set the item to in-progress:
-```bash
-gh project item-edit --project-id PVT_kwHOAtALr84BQs_6 --id <item_id> \
-  --field-id PVTSSF_lAHOAtALr84BQs_6zg-vxHc --single-select-option-id 47fc9ee4
-```
+Once decided, set the item to in-progress via `/backlog update BL-NNN status=in-progress`.
 
 Then hand off to the user: "Ready to go. Work on the task, then run `/daily wrap` when you're done — or I'll remind you."
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `gh project item-edit` commands from `/daily` and `/commit` skills
- Both now delegate to `/backlog update BL-NNN status=in-progress` for status transitions
- Adds auto in-progress step to `/commit` Step 1 when a matching backlog item is found
- Field IDs now live in one place (`/backlog` skill)

## Backlog
- None

## Test plan
- [ ] `/commit` sets matching backlog items to in-progress when found
- [ ] `/daily start` sets picked item to in-progress via `/backlog update`
- [ ] No hardcoded field IDs remain outside `/backlog` skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)