### PR TITLE
feat: configurable quiz length, clean AI defaults, fix search placeholder

### DIFF
--- a/src/data/translations/da.ts
+++ b/src/data/translations/da.ts
@@ -33,7 +33,7 @@ const da: Record<TranslationKeys, string> = {
   'header.soon': 'Snart',
   'header.module': 'Modul',
   'header.signIn': 'Log ind',
-  'header.lookupPlaceholder': 'Slå et ord op',
+  'header.lookupPlaceholder': 'Skriv et dansk ord',
   'header.selectModule': 'Vælg modul',
   'header.darkMode.light': 'Skift til lys tilstand',
   'header.darkMode.dark': 'Skift til mørk tilstand',
@@ -73,6 +73,8 @@ const da: Record<TranslationKeys, string> = {
   'quiz.grammarTopic': 'Grammatisk emne',
   'quiz.exerciseType': 'Øvelsestype',
   'quiz.exercises': '{count} øvelser',
+  'quiz.sessionLength': 'Spørgsmål per session',
+  'quiz.allCount': 'Alle ({count})',
   'quiz.backToSelector': 'Tilbage til vælger',
 
   // Drill
@@ -196,7 +198,7 @@ const da: Record<TranslationKeys, string> = {
   // Dictionary
   'dictionary.title': 'Dansk Ordbog',
   'dictionary.subtitle': 'Slå danske ord op — betydning, bøjning og eksempler',
-  'dictionary.placeholder': 'Skriv et dansk ord...',
+  'dictionary.placeholder': 'Skriv et dansk ord',
   'dictionary.lookup': 'Slå op',
   'dictionary.poweredBy': 'Drevet af Den Danske Ordbog (ordnet.dk)',
   'dictionary.recent': 'Seneste søgninger',

--- a/src/data/translations/en.ts
+++ b/src/data/translations/en.ts
@@ -31,7 +31,7 @@ const en = {
   'header.soon': 'Soon',
   'header.module': 'Module',
   'header.signIn': 'Sign in',
-  'header.lookupPlaceholder': 'Look up a word',
+  'header.lookupPlaceholder': 'Type a Danish word',
   'header.selectModule': 'Select module',
   'header.darkMode.light': 'Switch to light mode',
   'header.darkMode.dark': 'Switch to dark mode',
@@ -71,6 +71,8 @@ const en = {
   'quiz.grammarTopic': 'Grammar topic',
   'quiz.exerciseType': 'Exercise type',
   'quiz.exercises': '{count} exercises',
+  'quiz.sessionLength': 'Questions per session',
+  'quiz.allCount': 'All ({count})',
   'quiz.backToSelector': 'Back to selector',
 
   // Drill
@@ -194,7 +196,7 @@ const en = {
   // Dictionary
   'dictionary.title': 'Danish Dictionary',
   'dictionary.subtitle': 'Look up Danish words, meanings, inflections, and usage examples',
-  'dictionary.placeholder': 'Type a Danish word...',
+  'dictionary.placeholder': 'Type a Danish word',
   'dictionary.lookup': 'Look up',
   'dictionary.poweredBy': 'Powered by Den Danske Ordbog (ordnet.dk)',
   'dictionary.recent': 'Recent searches',

--- a/src/lib/ai-provider.ts
+++ b/src/lib/ai-provider.ts
@@ -15,7 +15,7 @@ export interface ProviderConfig {
   model: string
 }
 
-const PROVIDER_DEFAULTS: Record<AIProvider, { model: string; baseUrl?: string }> = {
+export const PROVIDER_DEFAULTS: Record<AIProvider, { model: string; baseUrl?: string }> = {
   anthropic: { model: 'claude-haiku-4-5-20251001' },
   ollama: { model: 'llama3.1', baseUrl: 'http://localhost:11434' },
   openrouter: { model: 'qwen/qwen3-80b:free' },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -60,6 +60,7 @@ export const SETTINGS_KEYS = {
   OLLAMA_URL: 'danskprep_ollama_url',
   OPENROUTER_KEY: 'danskprep_openrouter_key',
   OPENAI_KEY: 'danskprep_openai_api_key',
+  QUIZ_MAX_QUESTIONS: 'danskprep_quiz_max_questions',
   WELCOME_SEEN: 'danskprep_welcome_seen',
   BUBBLE_NICKNAME: 'danskprep_bubble_nickname',
   BUBBLE_SCORES: 'danskprep_bubble_scores',

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -15,7 +15,7 @@ import { FeedbackPanel } from '@/components/quiz/FeedbackPanel'
 import { QuizResults } from '@/components/quiz/QuizResults'
 import exercisesData from '@/data/seed/exercises-pd3m2.json'
 import type { Exercise } from '@/types/quiz'
-import { GRAMMAR_TOPIC_SLUGS, EXERCISE_TYPE_LABELS } from '@/lib/constants'
+import { GRAMMAR_TOPIC_SLUGS, EXERCISE_TYPE_LABELS, SETTINGS_KEYS } from '@/lib/constants'
 import { cn, shuffle } from '@/lib/utils'
 import { FeedbackButton } from '@/components/feedback/FeedbackButton'
 import { loadUserExercises, toExercise } from '@/lib/user-exercises'
@@ -32,9 +32,12 @@ const TOPIC_LABELS: Record<string, string> = {
   'pronouns': 'Pronouns',
 }
 
+const QUIZ_SESSION_LENGTHS = [10, 15, 20, 30, 0] as const  // 0 = all
+
 interface QuizConfig {
   topicSlug: string
   exerciseType: string
+  maxQuestions: number  // 0 = unlimited
 }
 
 export function QuizPage() {
@@ -60,7 +63,8 @@ export function QuizPage() {
     if (cfg.exerciseType !== 'all') {
       filtered = filtered.filter(e => e.exercise_type === cfg.exerciseType)
     }
-    return shuffle(filtered).slice(0, 15)
+    const shuffled = shuffle(filtered)
+    return cfg.maxQuestions > 0 ? shuffled.slice(0, cfg.maxQuestions) : shuffled
   }
 
   function startQuiz(cfg: QuizConfig) {
@@ -125,7 +129,7 @@ export function QuizPage() {
         <h1 className="text-2xl font-bold">{t('quiz.title')}</h1>
         <p className="text-muted-foreground text-sm mt-1">{t('quiz.subtitle')}</p>
       </div>
-      <QuizSelector onStart={startQuiz} initialTopic={initialTopic} />
+      <QuizSelector onStart={startQuiz} initialTopic={initialTopic} allExercises={allExercises} />
     </PageContainer>
   )
 }
@@ -261,14 +265,33 @@ function FilterChip({ active, onClick, children }: FilterChipProps) {
 interface QuizSelectorProps {
   onStart: (config: QuizConfig) => void
   initialTopic?: string
+  allExercises: Exercise[]
 }
 
-function QuizSelector({ onStart, initialTopic = GRAMMAR_TOPIC_SLUGS[0] }: QuizSelectorProps) {
+function QuizSelector({ onStart, initialTopic = GRAMMAR_TOPIC_SLUGS[0], allExercises }: QuizSelectorProps) {
   const [topicSlug, setTopicSlug] = useState<string>(initialTopic)
   const [exerciseType, setExerciseType] = useState('all')
+  const [maxQuestions, setMaxQuestions] = useState<number>(() => {
+    const stored = localStorage.getItem(SETTINGS_KEYS.QUIZ_MAX_QUESTIONS)
+    return stored ? Number(stored) : 15
+  })
   const { t } = useTranslation()
 
   const availableTypes = ['all', ...Object.keys(EXERCISE_TYPE_LABELS)]
+
+  // Count matching exercises for the current filters
+  const matchingCount = useMemo(() => {
+    let filtered = allExercises.filter(e => e.grammar_topic_slug === topicSlug)
+    if (exerciseType !== 'all') {
+      filtered = filtered.filter(e => e.exercise_type === exerciseType)
+    }
+    return filtered.length
+  }, [allExercises, topicSlug, exerciseType])
+
+  function handleMaxQuestionsChange(value: number) {
+    setMaxQuestions(value)
+    localStorage.setItem(SETTINGS_KEYS.QUIZ_MAX_QUESTIONS, String(value))
+  }
 
   return (
     <div className="space-y-6">
@@ -310,9 +333,28 @@ function QuizSelector({ onStart, initialTopic = GRAMMAR_TOPIC_SLUGS[0] }: QuizSe
         </div>
       </div>
 
+      {/* Session length */}
+      <div className="space-y-2">
+        <p className="text-sm font-medium">{t('quiz.sessionLength')}</p>
+        <div className="flex flex-wrap gap-2">
+          {QUIZ_SESSION_LENGTHS.map(n => (
+            <FilterChip
+              key={n}
+              active={maxQuestions === n}
+              onClick={() => handleMaxQuestionsChange(n)}
+            >
+              {n === 0 ? t('quiz.allCount', { count: matchingCount }) : String(n)}
+            </FilterChip>
+          ))}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {t('quiz.exercises', { count: matchingCount })}
+        </p>
+      </div>
+
       <Button
         className="w-full"
-        onClick={() => onStart({ topicSlug, exerciseType })}
+        onClick={() => onStart({ topicSlug, exerciseType, maxQuestions })}
       >
         {t('quiz.start')}
       </Button>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { SETTINGS_KEYS, DAILY_NEW_CARDS_LIMIT } from '@/lib/constants'
 import type { AIProvider } from '@/lib/ai-provider'
-import { getProviderConfig, saveProviderConfig, testOllamaConnection } from '@/lib/ai-provider'
+import { getProviderConfig, saveProviderConfig, testOllamaConnection, PROVIDER_DEFAULTS } from '@/lib/ai-provider'
 import { useTranslation } from '@/lib/i18n'
 import { ExternalLink } from 'lucide-react'
 
@@ -29,17 +29,27 @@ export function SettingsPage() {
   const [anthropicKey, setAnthropicKey] = useState(
     () => localStorage.getItem(SETTINGS_KEYS.ANTHROPIC_KEY) ?? ''
   )
-  const [ollamaUrl, setOllamaUrl] = useState(providerConfig.provider === 'ollama' ? providerConfig.baseUrl ?? 'http://localhost:11434' : 'http://localhost:11434')
-  const [ollamaModel, setOllamaModel] = useState(providerConfig.provider === 'ollama' ? providerConfig.model : 'llama3.1')
+  const [ollamaUrl, setOllamaUrl] = useState(
+    () => localStorage.getItem(SETTINGS_KEYS.OLLAMA_URL) ?? ''
+  )
+  const [ollamaModel, setOllamaModel] = useState(
+    () => providerConfig.provider === 'ollama' ? providerConfig.model : ''
+  )
   const [openrouterKey, setOpenrouterKey] = useState(
     () => localStorage.getItem(SETTINGS_KEYS.OPENROUTER_KEY) ?? ''
   )
-  const [openrouterModel, setOpenrouterModel] = useState(providerConfig.provider === 'openrouter' ? providerConfig.model : 'qwen/qwen3-80b:free')
+  const [openrouterModel, setOpenrouterModel] = useState(
+    () => providerConfig.provider === 'openrouter' ? providerConfig.model : ''
+  )
   const [openaiKey, setOpenaiKey] = useState(
     () => localStorage.getItem(SETTINGS_KEYS.OPENAI_KEY) ?? ''
   )
-  const [openaiModel, setOpenaiModel] = useState(providerConfig.provider === 'openai' ? providerConfig.model : 'gpt-4o-mini')
-  const [anthropicModel, setAnthropicModel] = useState(providerConfig.provider === 'anthropic' ? providerConfig.model : 'claude-haiku-4-5-20251001')
+  const [openaiModel, setOpenaiModel] = useState(
+    () => providerConfig.provider === 'openai' ? providerConfig.model : ''
+  )
+  const [anthropicModel, setAnthropicModel] = useState(
+    () => providerConfig.provider === 'anthropic' ? providerConfig.model : ''
+  )
   const [ollamaTestResult, setOllamaTestResult] = useState<string | null>(null)
   const [ollamaTesting, setOllamaTesting] = useState(false)
 
@@ -55,7 +65,7 @@ export function SettingsPage() {
   async function handleOllamaTest() {
     setOllamaTesting(true)
     setOllamaTestResult(null)
-    const result = await testOllamaConnection(ollamaUrl)
+    const result = await testOllamaConnection(ollamaUrl.trim() || PROVIDER_DEFAULTS.ollama.baseUrl!)
     if (result.ok) {
       setOllamaTestResult(`Connected! Models: ${result.models?.join(', ') ?? 'none'}`)
     } else {
@@ -69,24 +79,28 @@ export function SettingsPage() {
     localStorage.setItem(SETTINGS_KEYS.ACCEPT_LATIN_FALLBACK, String(acceptLatin))
     localStorage.setItem(SETTINGS_KEYS.DARK_MODE, String(darkMode))
 
-    // Save AI provider config
+    // Save AI provider config — use provider defaults when fields are left empty
     if (aiProvider === 'anthropic') {
       if (anthropicKey.trim()) {
         localStorage.setItem(SETTINGS_KEYS.ANTHROPIC_KEY, anthropicKey.trim())
       }
-      saveProviderConfig({ provider: 'anthropic', apiKey: anthropicKey.trim() || undefined, model: anthropicModel })
+      saveProviderConfig({ provider: 'anthropic', apiKey: anthropicKey.trim() || undefined, model: anthropicModel.trim() || PROVIDER_DEFAULTS.anthropic.model })
     } else if (aiProvider === 'ollama') {
-      saveProviderConfig({ provider: 'ollama', baseUrl: ollamaUrl, model: ollamaModel })
+      saveProviderConfig({
+        provider: 'ollama',
+        baseUrl: ollamaUrl.trim() || PROVIDER_DEFAULTS.ollama.baseUrl,
+        model: ollamaModel.trim() || PROVIDER_DEFAULTS.ollama.model,
+      })
     } else if (aiProvider === 'openrouter') {
       if (openrouterKey.trim()) {
         localStorage.setItem(SETTINGS_KEYS.OPENROUTER_KEY, openrouterKey.trim())
       }
-      saveProviderConfig({ provider: 'openrouter', apiKey: openrouterKey.trim() || undefined, model: openrouterModel })
+      saveProviderConfig({ provider: 'openrouter', apiKey: openrouterKey.trim() || undefined, model: openrouterModel.trim() || PROVIDER_DEFAULTS.openrouter.model })
     } else if (aiProvider === 'openai') {
       if (openaiKey.trim()) {
         localStorage.setItem(SETTINGS_KEYS.OPENAI_KEY, openaiKey.trim())
       }
-      saveProviderConfig({ provider: 'openai', apiKey: openaiKey.trim() || undefined, model: openaiModel })
+      saveProviderConfig({ provider: 'openai', apiKey: openaiKey.trim() || undefined, model: openaiModel.trim() || PROVIDER_DEFAULTS.openai.model })
     }
 
     setSaved(true)


### PR DESCRIPTION
## Summary
- **BL-035**: Add session length selector (10/15/20/30/All) to quiz config using existing FilterChip pattern. Persisted in localStorage, default 15.
- **BL-036**: Remove pre-filled defaults from AI provider settings. Inputs start empty with placeholders; empty fields fall back to provider defaults on save.
- **BL-037**: Update search placeholder to "Type a Danish word" / "Skriv et dansk ord" in header and dictionary page. Removed trailing ellipsis for consistency.

## Backlog
- Closes #75
- Closes #76
- Closes #77

## Test plan
- [ ] `npx tsc --noEmit` + `npm run build` + `npx vitest run` — all pass (91 tests)
- [ ] Quiz page shows session length picker with 10/15/20/30/All options
- [ ] AI settings inputs start empty when unconfigured, placeholders show expected format
- [ ] Header and dictionary search show "Type a Danish word" placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)