### PR TITLE
release: v0.7.1 — Mobile Header & Settings Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "danskprep",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/data/seed/changelog.json
+++ b/src/data/seed/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "0.7.1",
+    "date": "2026-03-04",
+    "title": "Mobile Header & Settings Fixes",
+    "highlights": [
+      "Module dropdown no longer clipped on mobile — changed overflow strategy",
+      "Mobile header fits 375px screens — hidden support button, compact icons",
+      "AI provider no longer defaults to Anthropic — must be explicitly chosen",
+      "Removed redundant localStorage writes in Settings save"
+    ],
+    "stats": {
+      "exercises": 292,
+      "words": 376,
+      "grammar_topics": 6,
+      "writing_prompts": 10,
+      "speaking_prompts": 8
+    }
+  },
+  {
     "version": "0.7.0",
     "date": "2026-03-04",
     "title": "Quiz Customization & Process Automation",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '0.7.0'
+export const APP_VERSION = '0.7.1'
 
 // Feature flags
 export const FEATURES = {


### PR DESCRIPTION
## Summary
- Fix module dropdown clipped by header overflow on mobile
- Fix mobile header icons cut off on narrow screens (375px)
- Fix AI provider defaulting to Anthropic when unconfigured — add explicit "Not configured" state
- Remove redundant localStorage writes in Settings

## Backlog
- Closes #73 <!-- BL-033: Redesign mobile header — move icons to sidebar -->

## Release checklist
- [x] Changelog updated (`src/data/seed/changelog.json`)
- [x] Version synced (changelog, constants.ts, package.json)
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds

## Content stats
- Exercises: 292
- Words: 376
- Grammar topics: 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)