### PR TITLE
chore: release v0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "danskprep",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/data/seed/changelog.json
+++ b/src/data/seed/changelog.json
@@ -1,5 +1,22 @@
 [
   {
+    "version": "0.7.2",
+    "date": "2026-03-04",
+    "title": "Mobile Sidebar Quick Actions",
+    "highlights": [
+      "Utility icons (dark mode, language, game, support, auth) moved to sidebar on mobile — header now clean with just hamburger, logo, and module selector",
+      "New Quick Actions section in mobile sidebar drawer for easy access to all controls",
+      "Floating word bubbles now clickable on every page, not just the welcome screen"
+    ],
+    "stats": {
+      "exercises": 292,
+      "words": 376,
+      "grammar_topics": 6,
+      "writing_prompts": 10,
+      "speaking_prompts": 8
+    }
+  },
+  {
     "version": "0.7.1",
     "date": "2026-03-04",
     "title": "Mobile Header & Settings Fixes",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '0.7.1'
+export const APP_VERSION = '0.7.2'
 
 // Feature flags
 export const FEATURES = {


### PR DESCRIPTION
## Release v0.7.2 — Mobile Sidebar Quick Actions

### Highlights
- Utility icons (dark mode, language, game, support, auth) moved to sidebar on mobile — header now clean with just hamburger, logo, and module selector
- New Quick Actions section in mobile sidebar drawer for easy access to all controls
- Floating word bubbles now clickable on every page, not just the welcome screen

### PRs included
- #91 — feat: move header utility icons to mobile sidebar Quick Actions
- #89 — fix: mobile header overflow, dropdown clipping, AI provider default

### Version sync
- `src/data/seed/changelog.json` → 0.7.2
- `src/lib/constants.ts` → 0.7.2
- `package.json` → 0.7.2

### Stats
292 exercises · 376 words · 6 grammar topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)