### PR TITLE
release: v0.8.0 — Content Pipeline & Developer Guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "danskprep",
   "private": true,
-  "version": "0.7.2",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/data/seed/changelog.json
+++ b/src/data/seed/changelog.json
@@ -1,5 +1,27 @@
 [
   {
+    "version": "0.8.0",
+    "date": "2026-03-04",
+    "title": "Content Pipeline & Developer Guide",
+    "highlights": [
+      "Exercises expanded from 292 to 933 — full SpeakSpeak H5P content pipeline with per-blank extraction",
+      "Vocabulary expanded from 376 to 595 words with AI-enriched inflections",
+      "All exercise hints translated to English (were mixed Danish/English)",
+      "14 writing prompts (up from 10), 11 speaking prompts (up from 8)",
+      "New DEVELOPMENT.md with workflow diagrams, skills/agents reference, and content pipeline overview",
+      "Slimmed README — developer content moved to DEVELOPMENT.md and docs/architecture.md",
+      "New content pipeline scripts: full-course scraper, H5P processor, exercise generator",
+      "Fixed /daily skill — removed redundant /simplify step (already in /commit)"
+    ],
+    "stats": {
+      "exercises": 933,
+      "words": 595,
+      "grammar_topics": 6,
+      "writing_prompts": 14,
+      "speaking_prompts": 11
+    }
+  },
+  {
     "version": "0.7.2",
     "date": "2026-03-04",
     "title": "Mobile Sidebar Quick Actions",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '0.7.2'
+export const APP_VERSION = '0.8.0'
 
 // Feature flags
 export const FEATURES = {


### PR DESCRIPTION
## Summary
- Exercises expanded from 292 to 933 via full SpeakSpeak H5P content pipeline with per-blank extraction
- Vocabulary expanded from 376 to 595 words with AI-enriched inflections, all hints translated to English
- New `DEVELOPMENT.md` with workflow diagrams, skills/agents reference, content pipeline overview
- Slimmed `README.md` — developer content moved to `DEVELOPMENT.md` and `docs/architecture.md`
- New content pipeline scripts: full-course scraper, H5P processor, exercise generator
- Fixed `/daily` skill — removed redundant `/simplify` step (already called by `/commit`)

## Backlog
- None

## Release checklist
- [x] Changelog updated (`src/data/seed/changelog.json`)
- [x] Version synced (changelog, constants.ts, package.json)
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (91 tests)
- [x] `npm run build` succeeds

## Content stats
- Exercises: 933
- Words: 595
- Grammar topics: 6
- Writing prompts: 14
- Speaking prompts: 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)