### PR TITLE
docs: context engineering retrospective + Day 0 starter kit

### DIFF
--- a/docs/retrospectives/2026-03-04-context-engineering-retrospective.md
+++ b/docs/retrospectives/2026-03-04-context-engineering-retrospective.md
@@ -1,0 +1,213 @@
+# Context Engineering Retrospective
+
+**Date:** 2026-03-04
+**Project:** DanskPrep v0.1.0 → v0.8.0
+**Scope:** 145 commits, 100 PRs, 8 releases, 4 days (March 1–4, 2026)
+**Author:** Claude Opus 4.6 + Yan Cheng
+
+---
+
+## Executive Summary
+
+Most rework in DanskPrep came from context that should have guided the AI from commit #1 being added only after mistakes were already made. Rules were reactive (fix bug → write rule) instead of proactive (write rule → prevent bug). Only 2 of 8 rules existed before the first commit. The `/commit` skill needed 6 iterations because the workflow was automated before it was designed on paper.
+
+This document captures every lesson learned, organized for reuse in future projects.
+
+---
+
+## Timeline
+
+| Day | Versions | Key Activity | Commits |
+|-----|----------|-------------|---------|
+| Mar 1 | v0.1.0 | Bootstrap → full app → Vercel → CI → data pipeline | ~15 |
+| Mar 2 | v0.2–v0.4.1 | Drill, feedback, writing/speaking, guest mode, bubble game, mobile fixes | ~60 |
+| Mar 3 | v0.5–v0.7.0 | Vocab enrichment, a11y, agent ecosystem, GitHub Projects, quiz config | ~45 |
+| Mar 4 | v0.7.1–v0.8.0 | Mobile header, content pipeline (292→933 exercises), docs | ~25 |
+
+Final state: 933 exercises, 595 words, 6 grammar topics, 22 skills, 7 agents, 8 rules, 7 references.
+
+---
+
+## What Went Wrong
+
+### 1. CLAUDE.md Started Thin, Grew Reactively
+
+The initial CLAUDE.md (commit `2838f54`) had a basic project overview, tech stack, and commands. Critical rules were added only after bugs:
+
+| Rule added | After which problem |
+|------------|-------------------|
+| "Floating bubbles must be `interactive={true}`" | 3 PRs flip-flopping (#29, #30, #91) |
+| "Unused imports fail CI" | Multiple CI failures |
+| "No `asChild` on Button" | Repeated incorrect code generation |
+| Guest-first UX | Retrofitting 15+ files in v0.4.0 |
+| Mobile-first enforcement | Header redesigned 3 times |
+| A11y requirements | 5+ separate a11y fix PRs |
+
+**Pattern:** AI makes mistake → human notices → rule added → AI stops. But 5-10 instances already exist.
+
+**Lesson:** Write CLAUDE.md as a **design document before commit #1**, not a growing FAQ of "things the AI got wrong."
+
+### 2. Rules Were Pitfall Patches, Not Design Constraints
+
+| Rule | When added | Trigger |
+|------|-----------|---------|
+| `react-conventions.md` | Day 1 | Initial scaffold |
+| `typescript-tooling.md` | Day 1 | Initial scaffold |
+| `supabase-workflow.md` | Day 2 | Forgot to sync migrations |
+| `nix-system-deps.md` | Day 2 | Someone tried `brew install` |
+| `python-lint.md` | Day 3 | Ruff errors in PRs |
+| `ui-feedback.md` | Day 3 | Couldn't locate UI elements |
+| `github-sync.md` | Day 3 | .claude/ and .github/ diverged |
+| `dev-guide-sync.md` | Day 4 | DEVELOPMENT.md went stale |
+
+Only 2/8 existed from Day 1. The other 6 were patches for problems that already happened.
+
+**Lesson:** Split rules into **architectural** (write before first commit) and **pitfall** (fine to add reactively).
+
+### 3. Skills Were Built After the Workflow Existed Manually
+
+- `/commit` created Day 2, modified 6 times through Day 3
+- `/release` built after manual version bumps
+- `/backlog` rewritten entirely when migrating from file to GitHub Projects
+- `/daily`, `/weekly` added Day 3 after the pattern was already informal
+
+11 skills created in commit #1, several deleted or rewritten later.
+
+**Lesson:** Design the 3 core lifecycle skills on paper first, then automate once. Don't speculate on domain skills before the domain stabilizes.
+
+### 4. Agents Had No Activation Criteria
+
+7 agents exist as `.md` files but no clear trigger for when to use each. Two original agents (`db-migrator`, `quiz-builder`) were created in commit #1 and deleted in PR #33 — they overlapped with skills.
+
+**Lesson:** Start with 1-2 agents. Every agent needs explicit activation criteria. Skills should be primary; agents orchestrate skills.
+
+### 5. References Lacked Glob Targeting Initially
+
+Three references use `globs:` frontmatter to auto-load when relevant files are opened — excellent pattern. But 4/7 references don't have globs and rely on manual skill loading.
+
+**Lesson:** Every reference should have `globs:` from the start. Zero-overhead, always-relevant context.
+
+---
+
+## Architectural Decisions That Should Have Been Day 0
+
+### Stable IDs
+
+Exercises used array-index IDs. Migration to stable IDs (BL-041) is still open at 933 exercises. At 201 exercises this was trivial.
+
+**Next time:** `sha256(source + topic + prompt)[:12]` from first import.
+
+### Database-First Content
+
+All content bundled as JSON. Grew from ~100KB to ~500KB+. Content updates require redeploy.
+
+**Next time:** DB-first from start. Seed JSON as bootstrap/fallback only.
+
+### Guest-First Auth
+
+Guest mode added v0.4.0 after drill, feedback, writing/speaking were built with auth assumptions. Touched 15+ files.
+
+**Next time:** Guest by default → sign-in for persistence. Day 1 architecture.
+
+### i18n Framework
+
+Added v0.3.0, hardcoded strings still scattered (BL-006, BL-007).
+
+**Next time:** `t('key')` from the first component or decide "no i18n" explicitly.
+
+### Accessibility
+
+5+ PRs for a11y fixes. ~130 WCAG color contrast violations still open.
+
+**Next time:** `eslint-plugin-jsx-a11y` in CI from Day 1. Per-component checklist.
+
+### Mobile-First
+
+Header redesigned 3 times. Floating bubbles needed 3 PRs. Multiple overflow fixes.
+
+**Next time:** Test 375px before merging. Mobile-first means building mobile first, not adding mobile after.
+
+### Security Model
+
+API keys in localStorage (XSS risk), no CSP, no rate limiting — all still open.
+
+**Next time:** Design security model alongside the feature that needs it.
+
+---
+
+## What Went Right (Keep These)
+
+1. **TypeScript strict from Day 1** — caught bugs early, enforced discipline
+2. **CLAUDE.md as living document** — single source of truth, continuously updated
+3. **Three-tier context loading** (CLAUDE.md always → rules always → references on-demand)
+4. **Frequent small releases** — 8 releases in 4 days, tight feedback loops
+5. **Checkpoints in agents** — human approval before irreversible actions
+6. **Learning filter in coder agent** — prevents context bloat
+7. **`/commit` skill with self-review** — catches issues before human review
+8. **Dual-path sync** (`.claude/` for AI, `.github/` for humans)
+9. **Seed data as versionable JSON** — easy to inspect, diff, validate
+10. **Nix + direnv** — reproducible environment
+
+---
+
+## The 7 Context Engineering Principles
+
+### 1. Rules Before Code, Not After Bugs
+Architectural rules before first commit. Pitfall rules can be reactive.
+
+### 2. One Source of Truth per Concern
+DanskPrep had version in 3 places, backlog in 2 systems, UI rules in both `rules/` and `references/`. Every piece of knowledge should live in exactly one place.
+
+### 3. Globs Are the Best Context Engineering
+`globs:` frontmatter on references delivers the right context at the right time with zero manual effort. Use it everywhere.
+
+### 4. Skills > Agents for Most Work
+Skills are predictable, testable, composable. Agents are autonomous but harder to control. Default to skills.
+
+### 5. Design Workflows on Paper, Then Automate Once
+`/commit` was modified 6 times. The final workflow was predictable. Write the workflow as a document first.
+
+### 6. Don't Speculate — Build When You Need It
+11 skills in commit #1, many deleted/rewritten. Create when you have a concrete, repeatable workflow.
+
+### 7. The Learning Filter Is Essential
+"Add only if confirmed across multiple interactions." "Always simplify to shortest useful form." Apply to all rule/reference creation.
+
+---
+
+## Rework Costs (Quantified)
+
+| Issue | PRs spent | What it could have been |
+|-------|----------|----------------------|
+| Floating bubbles UX | 3 PRs (#29, #30, #91) | 0 — define interaction model upfront |
+| Mobile header | 4 PRs (#27, #35, #89, #91) | 1 — design mobile-first from start |
+| A11y fixes | 5+ PRs (#35, #40, #87, etc.) | 0 — a11y lint in CI from Day 1 |
+| `/commit` skill iterations | 6 modifications | 1 — design on paper first |
+| Superseded PRs | 5 PRs closed (#13-15, #17-18) | 0 — plan before PR |
+| Guest mode retrofit | 1 large PR touching 15+ files | 0 — guest-first architecture |
+| Backlog migration | 1 large PR (786+/862-) | 0 — choose GitHub Projects from start |
+| Version sync bugs | Multiple hotfix commits | 0 — single source of truth for version |
+
+**Estimated:** ~25 PRs of rework that could have been 0-3 PRs with upfront design.
+
+---
+
+## Day 0 Checklist for Next Project
+
+Before the first feature commit, verify:
+
+- [ ] CLAUDE.md has architecture decisions (auth, data flow, IDs, i18n, security)
+- [ ] CLAUDE.md has UX invariants (mobile viewport, touch targets, a11y, interaction rules)
+- [ ] CLAUDE.md has quality gates (tsc, lint, test, build, a11y lint, mobile check)
+- [ ] 4-6 architectural rules exist (data, auth, a11y, mobile, security, shipping)
+- [ ] `/commit`, `/backlog`, `/release` skills are fully designed
+- [ ] 1-2 core agents only (`coder` with learning filter, `reviewer`)
+- [ ] All references have `globs:` targeting relevant source files
+- [ ] `settings.local.json` pre-approves safe commands
+- [ ] CI includes a11y lint (`eslint-plugin-jsx-a11y`)
+- [ ] Dependency strategy configured (Dependabot grouping, weekly merge window)
+- [ ] Data model decided (stable IDs, DB-vs-bundled, seed format)
+- [ ] i18n decision made (yes/no), framework chosen if yes
+- [ ] Guest flow designed if applicable
+
+See `templates/day0-starter-kit/` for the ready-to-copy template.

--- a/templates/day0-starter-kit/.claude/agents/coder.md
+++ b/templates/day0-starter-kit/.claude/agents/coder.md
@@ -1,0 +1,68 @@
+---
+name: coder
+description: "Autonomous dev cycle: pick work, implement, test, ship"
+---
+
+# Coder Agent
+
+Autonomous development agent that picks work from the backlog and ships it through the full lifecycle.
+
+## Activation Criteria
+- **Use when:** there are ready backlog items and the user wants autonomous development
+- **Don't use when:** the user wants to manually drive development or is exploring/researching
+
+## Phases
+
+### Phase 1: Pick Work
+Run `/backlog next` to select the highest-priority ready item.
+Present the item to the user for confirmation before starting.
+
+### Phase 2: Plan
+1. Read relevant code files
+2. Identify existing patterns, utilities, and components to reuse
+3. Draft implementation approach
+4. **CHECKPOINT:** Present plan to user. Wait for approval.
+
+### Phase 3: Implement
+Follow existing patterns. Reuse before creating new.
+
+**Blocker protocol:**
+| Blocker | Action |
+|---------|--------|
+| Missing type/interface | Check `src/types/`, create if truly missing |
+| Unclear requirement | Ask the user — never guess |
+| Failing test | Fix the code, not the test |
+| Import error | Check existing exports first |
+
+### Phase 4: Quality Gate
+All must pass:
+```bash
+npx tsc --noEmit
+npm run lint
+npm test -- --run
+npm run build
+```
+If any fails → fix and re-run. Do not proceed with failures.
+
+### Phase 5: Ship
+Run `/commit` — includes self-review, CI, human checkpoint.
+
+### Phase 6: Cleanup
+1. `/backlog done {item}`
+2. Delete plan/temp docs
+
+## Learning Filter
+
+When you discover a new pattern or pitfall during development:
+
+**Add to rules/ if:**
+- Confirmed across 2+ interactions (not a one-off)
+- Applies to future work (not specific to one feature)
+- Can be stated in 1-3 sentences
+
+**Do NOT add if:**
+- Specific to one feature or file
+- Already documented in CLAUDE.md or existing rules
+- Speculative or unverified
+
+**Format:** Always distill to the shortest useful form. If it takes a paragraph to explain, it's too long for a rule.

--- a/templates/day0-starter-kit/.claude/agents/project-review.md
+++ b/templates/day0-starter-kit/.claude/agents/project-review.md
@@ -1,0 +1,75 @@
+---
+name: project-review
+description: "8-dimension project health audit — read-only, produces scored report"
+---
+
+# Project Review Agent
+
+Read-only audit that evaluates the project across 8 dimensions. Never modifies code.
+
+## Activation Criteria
+- **Use when:** periodic health check, before major release, after significant changes
+- **Don't use when:** actively developing (use reviewer agent for PR-level review)
+
+## Dimensions
+
+### 1. Security
+- Secret scanning, dependency audit, auth/authz, input validation, CSP
+
+### 2. Tech Currency
+- Framework versions, deprecated APIs, EOL dependencies
+
+### 3. Data Model
+- Schema consistency, index coverage, RLS policies, migration hygiene
+
+### 4. Code Quality
+- Unused code, duplication, naming consistency, error handling, type safety
+
+### 5. Accessibility
+- ARIA attributes, keyboard navigation, color contrast, screen reader support
+
+### 6. Performance
+- Bundle size, lazy loading, unnecessary re-renders, query efficiency
+
+### 7. Mobile UX
+- 375px layouts, touch targets, viewport overflow, virtual keyboard handling
+
+### 8. i18n
+- Hardcoded strings, locale handling, RTL support (if applicable)
+
+## Scoring
+Each dimension: 0-10 score with findings.
+
+| Score | Meaning |
+|-------|---------|
+| 9-10 | Excellent — no issues |
+| 7-8 | Good — minor issues |
+| 5-6 | Acceptable — some gaps |
+| 3-4 | Concerning — significant gaps |
+| 0-2 | Critical — immediate attention needed |
+
+## Output Format
+
+```markdown
+## Project Review — [date]
+
+### Scorecard
+| Dimension | Score | Critical | High | Medium | Low |
+|-----------|-------|----------|------|--------|-----|
+
+### Top 10 Findings
+| # | Severity | Dimension | Finding | File | Effort |
+|---|----------|-----------|---------|------|--------|
+
+### Detailed Findings
+[Per-dimension sections with evidence]
+
+### Action Plan
+[Prioritized recommendations]
+```
+
+## Rules
+- Read at least 20 files before reporting
+- Check both light and dark mode
+- Never modify code — report only
+- Max 500 lines in report

--- a/templates/day0-starter-kit/.claude/agents/reviewer.md
+++ b/templates/day0-starter-kit/.claude/agents/reviewer.md
@@ -1,0 +1,70 @@
+---
+name: reviewer
+description: "Read-only audit: code quality, a11y, security, mobile"
+---
+
+# Reviewer Agent
+
+Read-only audit agent. Reads code and produces a report. Never modifies code.
+
+## Activation Criteria
+- **Use when:** before merging a PR, after a major feature, or on a regular schedule
+- **Don't use when:** actively implementing — use the coder agent instead
+
+## Audit Dimensions
+
+### 1. Code Quality
+- Unused imports, dead code, duplicated logic
+- Consistent naming conventions
+- Proper error handling at system boundaries
+- No `any` types without justification
+
+### 2. Accessibility
+- `aria-label` on all icon-only buttons
+- `role` on custom widgets
+- Keyboard navigation works
+- Color contrast meets WCAG AA
+- `prefers-reduced-motion` respected
+
+### 3. Security
+- No secrets in code or localStorage
+- RLS enabled on all user-data tables
+- Input validation at system boundaries
+- No `dangerouslySetInnerHTML` without sanitization
+- CSP headers configured
+
+### 4. Mobile
+- No horizontal overflow at 375px
+- Touch targets >= 44x44px
+- Virtual keyboard doesn't hide submit buttons
+- Responsive navigation works
+
+### 5. Performance
+- No unnecessary re-renders
+- Large data lazy-loaded
+- Images optimized
+- Bundle size reasonable
+
+## Output Format
+
+```markdown
+## Audit Report — [date]
+
+### Summary
+[1-2 sentences: overall health]
+
+### Findings
+| # | Severity | Area | File | Issue |
+|---|----------|------|------|-------|
+| 1 | CRITICAL | ... | ... | ... |
+| 2 | WARNING | ... | ... | ... |
+
+### Recommendations
+[Prioritized list of actions]
+```
+
+## Rules
+- **Never modify code** — report only
+- Read at least 20 files before reporting
+- Check both light and dark mode
+- Test as both guest and authenticated user

--- a/templates/day0-starter-kit/.claude/agents/spike-research.md
+++ b/templates/day0-starter-kit/.claude/agents/spike-research.md
@@ -1,0 +1,68 @@
+---
+name: spike-research
+description: "Technical deep-dive research — produces structured spike report"
+---
+
+# Spike Research Agent
+
+Investigates technical questions and produces a structured decision document. Never modifies code.
+
+## Activation Criteria
+- **Use when:** evaluating a new technology, comparing approaches, investigating a technical question
+- **Don't use when:** the answer is obvious or already documented
+
+## Workflow
+
+1. Understand the question and constraints
+2. Search the codebase for existing related code
+3. Research externally (docs, benchmarks, examples)
+4. Analyze options against project constraints
+5. Write spike report
+
+## Report Template
+
+Save to `docs/spikes/YYYY-MM-DD-<slug>.md`:
+
+```markdown
+# Spike: [Question]
+
+**Status:** Decided / Open / Abandoned
+**Decision:** [1-sentence answer, if decided]
+**Date:** YYYY-MM-DD
+
+## Question
+[What are we trying to figure out?]
+
+## Context
+[Why does this matter? What prompted the investigation?]
+
+## Options Evaluated
+
+### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Effort:** xs/s/m/l/xl
+- **Risk:** low/medium/high
+
+### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Effort:** xs/s/m/l/xl
+- **Risk:** low/medium/high
+
+## Recommendation
+[Which option and why. Be concrete.]
+
+## Next Steps
+[Specific actions, not "it depends"]
+
+## References
+[Links to docs, benchmarks, examples]
+```
+
+## Rules
+- Search codebase FIRST before researching externally
+- Include concrete code examples where helpful
+- Be honest about unknowns and risks
+- Keep under 300 lines
+- Never modify code — research only

--- a/templates/day0-starter-kit/.claude/references/example-reference.md
+++ b/templates/day0-starter-kit/.claude/references/example-reference.md
@@ -1,0 +1,35 @@
+---
+# IMPORTANT: Every reference MUST have globs targeting relevant files.
+# This auto-loads the reference when the AI opens matching files.
+# Without globs, references are dead weight — they exist but never load.
+globs:
+  - "src/lib/example*.ts"
+  - "src/hooks/useExample*.ts"
+---
+
+# Example Reference
+
+> This is a template. Replace with your domain-specific knowledge.
+
+## When This Loads
+
+This reference auto-loads when the AI opens any file matching the globs above.
+This is the highest-ROI context engineering pattern — zero manual effort, always relevant.
+
+## How to Write Good References
+
+1. **Target specific files** via `globs:` — the narrower, the better
+2. **Include code patterns** the AI should follow (with examples)
+3. **Include anti-patterns** the AI should avoid (with examples)
+4. **Keep it concise** — if it's over 100 lines, split into multiple references
+5. **Update when patterns change** — stale references cause wrong code
+
+## Example Content
+
+```typescript
+// CORRECT pattern for this domain:
+const result = doThingCorrectly(input)
+
+// WRONG — never do this:
+const result = doThingIncorrectly(input) // because: [reason]
+```

--- a/templates/day0-starter-kit/.claude/references/github-sync-map.md
+++ b/templates/day0-starter-kit/.claude/references/github-sync-map.md
@@ -1,0 +1,33 @@
+---
+globs:
+  - ".github/**/*"
+  - ".claude/skills/**/*"
+  - ".claude/rules/**/*"
+---
+
+# GitHub Sync Map
+
+Cross-reference between AI path (`.claude/`) and manual path (`.github/`).
+
+<!-- CUSTOMIZE: Fill in your project's specific mappings -->
+
+| Concern | AI Path (.claude/) | Manual Path (.github/) | Source of Truth |
+|---------|-------------------|----------------------|----------------|
+| PR format | `references/pr-templates.md` | `pull_request_template.md` | PR template |
+| Branch naming | `rules/shipping-workflow.md` | `workflows/branch-name.yml` | Workflow |
+| CI checks | `skills/commit/SKILL.md` Step 0 | `workflows/ci.yml` | Workflow |
+| Issue creation | `skills/backlog/SKILL.md` | `ISSUE_TEMPLATE/*.yml` | Templates |
+| Labels | `skills/backlog/SKILL.md` | `labels.yml` | `labels.yml` |
+| Release flow | `skills/release/SKILL.md` | `workflows/release.yml` | Skill |
+| Code ownership | `CLAUDE.md` | `CODEOWNERS` | `CODEOWNERS` |
+| Dependencies | — | `dependabot.yml` | `dependabot.yml` |
+
+## Verification
+
+```bash
+# Check labels in sync
+diff <(yq '.[] | .name' .github/labels.yml | sort) <(gh label list --json name -q '.[].name' | sort)
+
+# Check branch convention matches workflow
+grep -o '"^[^"]*"' .github/workflows/branch-name.yml
+```

--- a/templates/day0-starter-kit/.claude/references/pr-templates.md
+++ b/templates/day0-starter-kit/.claude/references/pr-templates.md
@@ -1,0 +1,52 @@
+---
+globs:
+  - ".github/pull_request_template.md"
+  - ".claude/skills/commit/**"
+  - ".claude/skills/release/**"
+---
+
+# PR Templates
+
+## Standard PR (used by `/commit`)
+
+```bash
+gh pr create --title "type: short description" --body "$(cat <<'EOF'
+## Summary
+- What changed and why (2-4 bullets)
+
+## Backlog
+- Closes #NNN
+- None
+
+## Test plan
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npm run build` succeeds
+- [ ] Manual smoke test
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## Release PR (used by `/release`)
+
+```bash
+gh pr create --title "release: vX.Y.Z — short description" --body "$(cat <<'EOF'
+## Summary
+- Version bump to X.Y.Z
+- Changelog updated
+
+## Release checklist
+- [ ] Version synced across all locations
+- [ ] Changelog entry added
+- [ ] CI passing
+- [ ] Build verified
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## Rules
+- Always use HEREDOC for PR body (avoids shell escaping issues)
+- Link issues with `Closes #NNN` for auto-close on merge

--- a/templates/day0-starter-kit/.claude/rules/a11y-checklist.md
+++ b/templates/day0-starter-kit/.claude/rules/a11y-checklist.md
@@ -1,0 +1,52 @@
+# Accessibility Checklist
+
+## Per-Component Requirements
+
+Every component must satisfy these before merge:
+
+### Labels & Roles
+- [ ] Icon-only buttons have `aria-label` describing the action
+- [ ] Custom widgets (dropdowns, tabs, modals) have correct ARIA `role`
+- [ ] Form inputs have associated `<label>` elements or `aria-label`
+- [ ] Images have meaningful `alt` text (or `alt=""` if decorative)
+
+### Keyboard Navigation
+- [ ] All interactive elements are focusable (`tabIndex` if needed)
+- [ ] Custom dropdowns/menus close on `Escape`
+- [ ] Focus is trapped inside modals when open
+- [ ] Focus moves to new content after navigation (route changes)
+
+### Color & Contrast
+- [ ] Text meets WCAG AA contrast ratio (4.5:1 for normal text, 3:1 for large)
+- [ ] Information is not conveyed by color alone (use icons, text, patterns too)
+- [ ] Both light and dark mode meet contrast requirements
+
+### Motion
+- [ ] Animations respect `prefers-reduced-motion` media query
+- [ ] No content relies solely on animation to convey meaning
+
+### Touch
+- [ ] Interactive elements are at least 44x44px
+- [ ] Sufficient spacing between touch targets (no accidental taps)
+
+## CI Enforcement
+
+Add `eslint-plugin-jsx-a11y` to ESLint config:
+
+```js
+// eslint.config.js
+import jsxA11y from 'eslint-plugin-jsx-a11y'
+
+// Add to your config:
+...jsxA11y.configs.recommended.rules
+```
+
+## Skip-to-Content
+
+Every page layout must include a skip-to-content link as the first focusable element:
+
+```tsx
+<a href="#main-content" className="sr-only focus:not-sr-only focus:absolute ...">
+  Skip to content
+</a>
+```

--- a/templates/day0-starter-kit/.claude/rules/auth-model.md
+++ b/templates/day0-starter-kit/.claude/rules/auth-model.md
@@ -1,0 +1,26 @@
+# Auth Model
+
+## Guest-First Architecture
+
+<!-- CUSTOMIZE: Adjust to your chosen auth model -->
+
+Users can use the app immediately without signing in. Sign-in unlocks persistence and sync.
+
+### What works without auth
+- Browse all content
+- Take quizzes and drills
+- View grammar topics and vocabulary
+
+### What requires sign-in
+- Save progress across sessions
+- Sync data across devices
+- Submit user-generated content
+- Access personal statistics
+
+### Implementation Rules
+
+1. **Never assume authentication** — every page must render for guests
+2. **No auth guards on read-only content** — only gate write operations
+3. **Show sign-in CTAs contextually** — when a guest tries a gated action, show a sign-in prompt explaining the benefit (e.g., "Sign in to save your progress")
+4. **Guest state is ephemeral** — lost on page refresh, and that's OK
+5. **Design components auth-agnostic** — pass `isGuest` as a prop, don't check auth inside components

--- a/templates/day0-starter-kit/.claude/rules/data-architecture.md
+++ b/templates/day0-starter-kit/.claude/rules/data-architecture.md
@@ -1,0 +1,44 @@
+# Data Architecture
+
+## ID Strategy
+
+<!-- CUSTOMIZE: Choose your strategy and delete this comment -->
+
+All entities must have a stable, deterministic ID assigned at creation time.
+
+**Pattern:** `sha256(source + type + content)[:12]`
+
+This ensures:
+- IDs survive re-imports and re-processing
+- No user_card / review_log references break on content updates
+- Seed data can be diffed meaningfully
+
+**Rules:**
+- Never use array indices as IDs
+- Never rely on auto-increment for content that may be re-seeded
+- Assign IDs in the data pipeline, not at insert time
+
+## Data Flow
+
+<!-- CUSTOMIZE: Choose API-first or bundled and delete this comment -->
+
+Content flows: **seed JSON → database → app fetches at runtime**
+
+- Seed JSON files are the source of truth for initial content
+- The app reads from the database at runtime (not bundled JSON)
+- Seed JSON serves as bootstrap data and offline fallback only
+- Content updates do NOT require a frontend redeploy
+
+## Seed Data Format
+
+- All seed files live in `src/data/seed/`
+- File naming: `{entity}-{scope}.json` (e.g., `exercises-pd3m2.json`)
+- Every record has a `source` field for provenance tracking
+- UTF-8 encoding, literal special characters (no escaped unicode)
+
+## Migration Workflow
+
+1. Create new migration file: `supabase/migrations/NNN_description.sql`
+2. Never modify existing migration files
+3. Run sync to push to remote database
+4. Generate types if schema changed

--- a/templates/day0-starter-kit/.claude/rules/dev-guide-sync.md
+++ b/templates/day0-starter-kit/.claude/rules/dev-guide-sync.md
@@ -1,0 +1,11 @@
+# Dev Guide Sync
+
+## Rule
+
+When any of these change, update DEVELOPMENT.md (or your project's dev guide):
+- A skill is added, removed, or renamed
+- An agent is added, removed, or renamed
+- Skill chaining changes (e.g., `/daily` now calls `/commit` differently)
+- Commands or setup steps change
+
+Also update the skills/agents table in CLAUDE.md if it exists.

--- a/templates/day0-starter-kit/.claude/rules/github-sync.md
+++ b/templates/day0-starter-kit/.claude/rules/github-sync.md
@@ -1,0 +1,27 @@
+# GitHub Sync Rule
+
+## Dual-Path Development
+
+This project has two development paths that must stay in sync:
+- **AI path:** `.claude/` (skills, rules, references, agents)
+- **Manual path:** `.github/` (workflows, templates, labels, CODEOWNERS)
+
+## When editing paired files
+
+When editing any skill, rule, or reference that has a `.github/` counterpart, update both in the same commit.
+
+See `.claude/references/github-sync-map.md` for the full mapping table.
+
+## When creating new skills
+
+Ask before creating a GitHub workflow equivalent:
+
+```
+This skill does X. A GitHub workflow could enforce/automate part of this for manual contributors:
+- Workflow: <what it would do>
+- Trigger: <when it would run>
+
+Want me to create it?
+```
+
+If confirmed, create the workflow and add both to the sync map.

--- a/templates/day0-starter-kit/.claude/rules/mobile-first.md
+++ b/templates/day0-starter-kit/.claude/rules/mobile-first.md
@@ -1,0 +1,36 @@
+# Mobile-First Development
+
+## Core Principle
+
+Mobile-first means **building for mobile first**, not "building for desktop then fixing mobile later."
+
+## Rules
+
+### Layout
+- Base styles target 375px (smallest supported viewport)
+- Use `md:` and `lg:` breakpoints to enhance for larger screens
+- Never use fixed widths — use `max-w-*`, `w-full`, percentages
+- Test for horizontal overflow: no element should cause horizontal scroll at 375px
+
+### Before Every PR Merge
+- [ ] Open Chrome DevTools → device toolbar → iPhone SE (375px)
+- [ ] Verify no horizontal overflow
+- [ ] Verify all touch targets are at least 44x44px
+- [ ] Verify text is readable without zooming
+- [ ] Test both portrait and landscape
+
+### Navigation
+- Mobile: hamburger menu / bottom nav / sidebar drawer
+- Desktop: full sidebar or top nav
+- Design the mobile navigation FIRST, then enhance for desktop
+
+### Inputs
+- Virtual keyboard pushes content up — ensure submit buttons remain visible
+- Use `inputmode` attribute for appropriate keyboard type
+- Touch targets: `min-h-11 min-w-11` (44px) on all interactive elements
+
+### Common Mistakes to Avoid
+- `overflow-hidden` on containers that clip dropdowns on mobile
+- Fixed headers that don't account for iOS safe area
+- Hover-only interactions with no touch/click equivalent
+- Modals/panels that don't go full-screen on mobile

--- a/templates/day0-starter-kit/.claude/rules/security-model.md
+++ b/templates/day0-starter-kit/.claude/rules/security-model.md
@@ -1,0 +1,48 @@
+# Security Model
+
+## Secrets & API Keys
+
+- **Never store API keys in localStorage** — extractable via XSS
+- **Never commit secrets** to git (`.env.local`, credentials, tokens)
+- **Third-party API calls** go through a serverless proxy (e.g., Vercel API routes)
+- Client-side code should never contain secrets — only public/anon keys
+
+## Content Security Policy
+
+Add CSP headers from Day 1 (via `vercel.json`, middleware, or meta tag):
+
+```json
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Database (RLS)
+
+- Every table with user data must have Row Level Security enabled
+- Public-read tables: `USING (true)` for SELECT, restricted for INSERT/UPDATE/DELETE
+- User-scoped tables: `USING (auth.uid() = user_id)` on all operations
+- Every UPDATE policy needs a `WITH CHECK` clause (not just `USING`)
+- Test RLS: query as anonymous user and verify only expected rows return
+
+## Rate Limiting
+
+- Unauthenticated write endpoints (feedback, contact forms) must have rate limiting
+- Options: Supabase edge functions, Vercel middleware, or DB-level constraints
+- Design this alongside the feature, not as a follow-up
+
+## Input Validation
+
+- Validate at system boundaries (user input, external APIs)
+- Sanitize HTML output — never use `dangerouslySetInnerHTML` without sanitization
+- Use parameterized queries — never interpolate user input into SQL

--- a/templates/day0-starter-kit/.claude/rules/shipping-workflow.md
+++ b/templates/day0-starter-kit/.claude/rules/shipping-workflow.md
@@ -1,0 +1,42 @@
+# Shipping Workflow
+
+## The Complete Flow (Design Once, Don't Iterate)
+
+```
+1. Pre-flight     — ensure main is up to date, no uncommitted changes
+2. Commit         — stage changes, write commit message (why, not what)
+3. Branch + PR    — create feature branch, push, open PR
+4. Self-review    — read the diff as a reviewer would, fix issues
+5. CI             — wait for all checks to pass
+6. Docs           — update README/docs if user-facing behavior changed
+7. Human approval — STOP and wait for human to approve
+8. Merge          — squash-merge into main
+9. Cleanup        — delete branch, update backlog status
+```
+
+## Rules
+
+- Never push directly to main
+- Never merge without passing CI + human approval
+- Never auto-merge without explicit user permission
+- Never amend published commits — create new ones
+- Never skip pre-commit hooks (`--no-verify`)
+- Commit messages explain WHY, not WHAT
+
+## Branch Naming
+
+```
+fix/description      — bug fixes
+feat/description     — new features
+docs/description     — documentation only
+chore/description    — refactoring, cleanup, tooling
+refactor/description — code restructuring
+release/vX.Y.Z      — release branches
+```
+
+## PR Body
+
+Always include:
+1. Summary (2-4 bullet points)
+2. Backlog references (`Closes #NNN`)
+3. Test checklist

--- a/templates/day0-starter-kit/.claude/skills/backlog/SKILL.md
+++ b/templates/day0-starter-kit/.claude/skills/backlog/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: backlog
+description: "Manage project backlog — add, list, filter, update, prioritize, suggest"
+user-invocable: true
+argument-hint: "<subcommand> [args]"
+---
+
+# /backlog — Backlog Management
+
+<!-- CUSTOMIZE: Choose your backend (GitHub Projects, GitHub Issues, or file-based) -->
+<!-- Wire up field IDs and project numbers before first use -->
+
+## Subcommands
+
+### `/backlog` or `/backlog dashboard`
+Show overview: in-progress items, ready items, blocked items, stats.
+
+### `/backlog add <title>`
+Create a new backlog item with:
+- Title (imperative: "Add X", "Fix Y")
+- Type: feature / bug / chore / infra / content
+- Priority: p0 (critical) / p1 (important) / p2 (default) / p3 (nice to have)
+- Effort: xs / s / m / l / xl
+
+### `/backlog list [filter]`
+List items. Filters: `ready`, `in-progress`, `blocked`, `type:bug`, `priority:p0`, etc.
+
+### `/backlog view <id>`
+Show full details of a specific item.
+
+### `/backlog update <id> <field=value>`
+Update an item's status, priority, effort, or assignee.
+
+### `/backlog done <id>`
+Mark item as complete. Move to Done status.
+
+### `/backlog next`
+Suggest the next item to work on based on:
+1. Priority (higher = first)
+2. Effort (smaller = first for quick wins)
+3. Blocked status (skip blocked items)
+4. Context (recently touched files)
+
+### `/backlog prioritize`
+Review all open items and re-rank by priority.

--- a/templates/day0-starter-kit/.claude/skills/commit/SKILL.md
+++ b/templates/day0-starter-kit/.claude/skills/commit/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: commit
+description: "Full ship cycle: branch, PR, self-review, fix, human approval, merge"
+user-invocable: true
+argument-hint: "[commit message]"
+---
+
+# /commit — Ship Code
+
+## Steps
+
+### Step 0: Pre-flight
+1. Run `git status` — ensure working tree is clean except for intended changes
+2. Run `git pull origin main` — ensure branch is up to date
+3. Run quality gates: `npx tsc --noEmit && npm run lint && npm test -- --run && npm run build`
+4. If any gate fails → fix before proceeding
+
+### Step 1: Commit
+1. Stage relevant files (never `git add -A` — be explicit)
+2. Write commit message explaining WHY, not WHAT
+3. Format: `type: description` (e.g., `feat: add quiz length selector`)
+
+### Step 2: Branch + Push
+1. Create branch if not on one: `git checkout -b {type}/{slug}`
+2. Push: `git push -u origin {branch}`
+
+### Step 3: Create PR
+1. Write summary (2-4 bullet points)
+2. Reference backlog items (`Closes #NNN`)
+3. Add test checklist
+
+### Step 4: Self-Review
+1. Read the full diff as if reviewing someone else's code
+2. Check for: unused imports, missing error handling, a11y, mobile
+3. Fix any issues found, commit, push
+
+### Step 5: Wait for CI
+1. All checks must pass before proceeding
+
+### Step 6: Update Docs (if needed)
+- [ ] README updated if user-facing behavior changed
+- [ ] CLAUDE.md updated if conventions changed
+
+### Step 7: HUMAN CHECKPOINT
+**STOP HERE.** Present the PR URL to the user and wait for explicit approval before merging. Never auto-merge.
+
+### Step 8: Merge + Cleanup
+1. Squash-merge into main
+2. Delete the feature branch (local + remote)
+3. Update backlog status if applicable

--- a/templates/day0-starter-kit/.claude/skills/daily/SKILL.md
+++ b/templates/day0-starter-kit/.claude/skills/daily/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: daily
+description: "Daily session wrapper — start with backlog, work, commit, retro"
+user-invocable: true
+argument-hint: "[start|wrap]"
+---
+
+# /daily — Daily Session Workflow
+
+## `/daily` or `/daily start` — Begin Session
+
+### Step 1: Backlog Dashboard
+Run `/backlog` to show current state: in-progress, ready, blocked items.
+
+### Step 2: Pick Work
+Run `/backlog next` to suggest highest-priority ready item.
+Present to user for confirmation.
+
+### STOP
+User works on the selected item. Resume with `/daily wrap` when done.
+
+## `/daily wrap` — End Session
+
+### Step 3: Ship
+Run `/commit` to ship completed work (includes self-review, CI, human approval).
+
+### Step 4: Retrospective
+Run `/retro` to summarize session, update backlog, suggest next priorities.

--- a/templates/day0-starter-kit/.claude/skills/qa-review/SKILL.md
+++ b/templates/day0-starter-kit/.claude/skills/qa-review/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: qa-review
+description: "Audit test coverage and write missing tests"
+user-invocable: true
+---
+
+# /qa-review — Test Coverage Audit
+
+## Steps
+
+### Step 1: Gather Coverage Data
+```bash
+npm test -- --run --coverage
+```
+
+### Step 2: Find Test Files
+Scan for existing test files (`.test.ts`, `.test.tsx`, `.spec.ts`).
+
+### Step 3: Coverage Status Table
+
+| Area | File | Has Tests | Coverage | Priority |
+|------|------|-----------|----------|----------|
+| ... | ... | yes/no | %/unknown | high/med/low |
+
+Priority is based on: complexity, risk if broken, frequency of change.
+
+### Step 4: Write Missing Tests
+For each high-priority gap:
+1. Write failing test first (BDD naming: "should X when Y")
+2. Verify it fails for the right reason
+3. If fixing a bug, the test should reproduce the bug
+
+### Step 5: Quality Gate
+```bash
+npm test -- --run    # All tests pass
+npx tsc --noEmit     # No type errors from test files
+```
+
+## Test Conventions
+- Co-locate tests: `foo.test.ts` next to `foo.ts`
+- BDD naming: `describe('functionName', () => { it('should X when Y', ...) })`
+- Test behavior, not implementation
+- Regression rule: write a failing test before fixing any bug

--- a/templates/day0-starter-kit/.claude/skills/release/SKILL.md
+++ b/templates/day0-starter-kit/.claude/skills/release/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: release
+description: "Cut a versioned release — changelog, version bump, release PR"
+user-invocable: true
+argument-hint: "[major|minor|patch]"
+---
+
+# /release — Cut a Release
+
+## Prerequisites
+- On `main` branch, fully up to date
+- All CI checks passing
+- At least one meaningful change since last release
+
+## Steps
+
+### Step 1: Assess Changes
+1. `git log v{last}..HEAD --oneline` — list all commits since last tag
+2. Categorize: features, fixes, chores, content, breaking changes
+3. Determine version bump:
+   - **major** — breaking changes
+   - **minor** — new features
+   - **patch** — bug fixes, content updates, chores
+
+### Step 2: Update Changelog
+<!-- CUSTOMIZE: Define where your changelog lives (ONE place) -->
+1. Add entry to changelog with: version, date, highlights, stats
+2. Keep entries concise (3-5 bullet points per release)
+
+### Step 3: Bump Version
+<!-- CUSTOMIZE: Define the SINGLE source of truth for version -->
+1. Update version in `package.json`
+2. If version appears elsewhere, update from this single source
+
+### Step 4: Create Release PR
+1. Branch: `release/vX.Y.Z`
+2. PR title: `release: vX.Y.Z — short description`
+3. PR body: changelog entry + release checklist
+
+### Step 5: HUMAN CHECKPOINT
+**STOP.** Present PR for review. Wait for approval.
+
+### Step 6: Merge + Tag
+1. Merge release PR
+2. CI auto-creates GitHub Release (if workflow configured)
+3. Verify deployment

--- a/templates/day0-starter-kit/.claude/skills/retro/SKILL.md
+++ b/templates/day0-starter-kit/.claude/skills/retro/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: retro
+description: "End-of-session retrospective — summarize work, update backlog, plan next"
+user-invocable: true
+---
+
+# /retro — Session Retrospective
+
+## Steps
+
+### Step 1: Gather Context
+1. `git log --oneline --since="8 hours ago"` — what was committed this session
+2. `git diff --stat HEAD~N` — scope of changes
+3. Review any open PRs from this session
+
+### Step 2: Categorize Work
+- **Done:** items fully completed and merged
+- **In progress:** items started but not finished
+- **Discovered:** new issues found during work
+- **Blocked:** items that can't proceed (and why)
+
+### Step 3: Update Backlog
+- Mark completed items as done (`/backlog done`)
+- Add newly discovered items (`/backlog add`)
+- Update blocked items with blocker info
+
+### Step 4: Write Summary
+```markdown
+## Session — YYYY-MM-DD
+
+### Done
+- [item]: [one-line description of what was accomplished]
+
+### In Progress
+- [item]: [what remains]
+
+### Discovered
+- [new issue]: [brief description]
+
+### Blocked
+- [item]: blocked by [reason]
+
+### Stats
+- Commits: N
+- Files changed: N
+- Lines: +N / -N
+```
+
+### Step 5: Suggest Next Priorities
+Based on current state, suggest 2-3 items for the next session.
+
+## Rules
+- Never fabricate work — only report what actually happened
+- Keep summaries concise (1 line per item)
+- If nothing was accomplished, say so honestly

--- a/templates/day0-starter-kit/.claude/skills/scope/SKILL.md
+++ b/templates/day0-starter-kit/.claude/skills/scope/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: scope
+description: "Break a backlog item into sub-tasks with effort estimates, risks, and affected files"
+user-invocable: true
+argument-hint: "<backlog-item-id or description>"
+---
+
+# /scope — Scope & Estimate
+
+## Steps
+
+### Step 1: Load Item
+If given a backlog ID, fetch the full description. Otherwise treat the argument as an ad-hoc description.
+
+### Step 2: Explore Codebase
+Use Glob, Grep, Read to understand:
+- What files will be touched
+- What existing patterns to follow
+- What utilities/hooks/components can be reused
+
+### Step 3: Break Down
+Decompose into 3-8 sub-tasks:
+
+| # | Task | Files | Effort | Dependencies | Notes |
+|---|------|-------|--------|-------------|-------|
+| 1 | ... | ... | xs/s/m/l | — | ... |
+| 2 | ... | ... | s | #1 | ... |
+
+### Step 4: Identify Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|-----------|-----------|
+| ... | high/med/low | high/med/low | ... |
+
+Risk categories to check:
+- Breaking existing functionality
+- Performance impact
+- Security implications
+- Mobile/responsive compatibility
+- Migration complexity
+
+### Step 5: Estimate Total
+Sum sub-task efforts + 20% buffer for unknowns.
+
+| Effort | Meaning |
+|--------|---------|
+| xs | < 30 min, trivial |
+| s | 30 min – 2 hours |
+| m | 2 – 4 hours |
+| l | 4 – 8 hours |
+| xl | Multi-session |
+
+### Step 6: Present & Offer Follow-up
+Present the scope document and offer:
+1. Update backlog with this scope
+2. Create sub-task items in backlog
+3. Start a spike for high-risk areas
+4. Start building immediately

--- a/templates/day0-starter-kit/.claude/skills/security-review/SKILL.md
+++ b/templates/day0-starter-kit/.claude/skills/security-review/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: security-review
+description: "Run a security audit covering OWASP Top 10, deps, secrets, auth"
+user-invocable: true
+---
+
+# /security-review — Security Audit
+
+## Checks
+
+### 1. Secret Scanning
+Grep for patterns that should never be in code:
+- API keys, tokens, passwords in source files
+- `.env` files committed to git
+- Hardcoded credentials in config
+
+### 2. Dependency Vulnerabilities
+```bash
+npm audit
+```
+Flag: CRITICAL and HIGH severity.
+
+### 3. Auth & Authorization
+- RLS enabled on all user-data tables (if using Supabase/Postgres)
+- UPDATE policies have `WITH CHECK` (not just `USING`)
+- No privilege escalation paths
+
+### 4. Client-Side Security
+- No secrets in localStorage or client-side code
+- No `dangerouslySetInnerHTML` without sanitization
+- No `eval()`, `innerHTML`, or `new Function()` with user input
+- CSP headers configured
+
+### 5. Environment Variables
+- No `VITE_` prefixed secrets (these are exposed to the client)
+- Service keys only used server-side
+- `.env.example` doesn't contain real values
+
+### 6. Input Validation
+- User input validated at system boundaries
+- No SQL injection vectors (parameterized queries)
+- No XSS vectors (proper escaping)
+
+## Output Format
+
+| # | Severity | Category | Finding | File | Recommendation |
+|---|----------|----------|---------|------|---------------|
+| 1 | CRITICAL | ... | ... | ... | ... |
+
+Severity: CRITICAL / HIGH / MEDIUM / LOW / INFO

--- a/templates/day0-starter-kit/.claude/skills/some/SKILL.md
+++ b/templates/day0-starter-kit/.claude/skills/some/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: some
+description: "Social media post generator — LinkedIn, Twitter/X, Facebook"
+user-invocable: true
+argument-hint: "<platform> [topic]"
+---
+
+# /some — Social Media Engineer
+
+## Subcommands
+
+### `/some linkedin [topic]`
+Generate a LinkedIn post. Format:
+- Hook line (bold, attention-grabbing)
+- 3-5 short paragraphs with line breaks
+- Numbered stats or bullet points
+- Call to action
+- 3-5 hashtags
+
+### `/some twitter [topic]`
+Generate a tweet or thread. Format:
+- Single tweet: < 280 chars, punchy
+- Thread: numbered tweets (1/N), first tweet is the hook
+
+### `/some facebook [topic]`
+Generate a Facebook post. Format:
+- Casual, conversational tone
+- Slightly longer than Twitter
+- Question or call to action at the end
+
+### `/some all [topic]`
+Generate for all platforms at once.
+
+## Rules
+- Read project state before every post (version, stats, recent changes)
+- Include numbers (X exercises, Y features, etc.)
+- Always include project URL and repo link
+- Use accessible language — no jargon
+- No hype or superlatives ("revolutionary", "game-changing")
+- Save output to `docs/some/YYYY-MM-DD-<slug>.md`

--- a/templates/day0-starter-kit/.claude/skills/update-changelog/SKILL.md
+++ b/templates/day0-starter-kit/.claude/skills/update-changelog/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: update-changelog
+description: "Add a new changelog entry, bump version, verify build"
+user-invocable: true
+argument-hint: "[major|minor|patch]"
+---
+
+# /update-changelog — Changelog & Version Bump
+
+<!-- CUSTOMIZE: Set your changelog location and version source of truth -->
+
+## Steps
+
+### Step 1: Read Current State
+- Read changelog file
+- Read current version from `package.json`
+- `git log v{last-tag}..HEAD --oneline` — changes since last release
+
+### Step 2: Summarize Highlights
+Categorize changes:
+- **Features:** new user-facing functionality
+- **Fixes:** bug fixes
+- **Content:** data/content additions (if applicable)
+- **Infrastructure:** CI/CD, tooling, dependencies
+
+Write 3-5 bullet point highlights (user-facing language, not commit messages).
+
+### Step 3: Determine Version Bump
+- **major** — breaking changes
+- **minor** — new features (default if features present)
+- **patch** — bug fixes, content, chores only
+
+### Step 4: Update Files
+1. Add changelog entry (newest first)
+2. Bump version in `package.json`
+<!-- CUSTOMIZE: Add any other files where version appears -->
+
+### Step 5: Verify
+```bash
+npx tsc --noEmit && npm run build
+```
+
+## Rules
+- Changelog entries are written for USERS, not developers
+- Use past tense ("Added X", "Fixed Y")
+- Keep entries concise — 1 line per change
+- **One source of truth for version** — `package.json` is canonical

--- a/templates/day0-starter-kit/.claude/skills/weekly/SKILL.md
+++ b/templates/day0-starter-kit/.claude/skills/weekly/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: weekly
+description: "Weekly review — prioritize backlog, review progress, release check, plan ahead"
+user-invocable: true
+argument-hint: "[review|plan]"
+---
+
+# /weekly — Weekly Review
+
+## `/weekly` or `/weekly review` — Full Review
+
+### Step 1: Week in Review
+- `git log --oneline --since="7 days ago"` — all commits this week
+- `gh pr list --state merged --search "merged:>YYYY-MM-DD"` — merged PRs
+- Summarize: features shipped, bugs fixed, infrastructure changes
+
+### Step 2: Backlog Health Check
+- **Stale in-progress:** items in-progress > 7 days without commits → flag
+- **P3 accumulation:** if > 10 p3 items → suggest review or bulk-close
+- **Ideas review:** scan `status:idea` items → promote or archive
+- **Missing metadata:** items without priority, effort, or area labels
+
+### Step 3: Prioritize
+Run `/backlog prioritize` — re-rank all open items.
+
+### Step 4: Release Check
+- Count changes since last tag
+- If meaningful changes exist → suggest `/release`
+- If not → note "no release needed"
+
+### Step 5: Plan the Week
+Output a MoSCoW plan:
+- **Must:** highest priority, blocking others
+- **Should:** important but not blocking
+- **Could:** nice to have if time allows
+- **Blocked:** needs external input or dependency resolution

--- a/templates/day0-starter-kit/.github/CODEOWNERS
+++ b/templates/day0-starter-kit/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS — auto-assigns reviewers on PRs
+# CUSTOMIZE: Replace @OWNER with your GitHub username
+
+# Global fallback
+* @OWNER
+
+# Architecture & Database
+# supabase/                         @OWNER
+# src/types/                        @OWNER
+
+# Security-sensitive paths
+# src/lib/supabase.ts               @OWNER
+# .env.example                      @OWNER
+
+# CI/CD
+.github/workflows/                @OWNER
+.github/CODEOWNERS                @OWNER
+
+# SDLC governance
+CLAUDE.md                         @OWNER

--- a/templates/day0-starter-kit/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/templates/day0-starter-kit/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Report a bug or incorrect behaviour
+labels: ["type:bug"]
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      # CUSTOMIZE: Add project-specific areas
+      options:
+        - area:ui
+        - area:auth
+        - area:db
+        - area:dx
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - p0 — critical / blocks users
+        - p1 — important / should fix soon
+        - p2 — default
+        - p3 — nice to have
+      default: 2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - xs — trivial
+        - s — straightforward
+        - m — medium (default)
+        - l — complex / multiple files
+        - xl — epic / multi-session
+      default: 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+      placeholder: |
+        **Steps to reproduce:**
+        1. Go to ...
+        2. Click ...
+
+        **Expected:** ...
+        **Actual:** ...
+    validations:
+      required: true

--- a/templates/day0-starter-kit/.github/ISSUE_TEMPLATE/config.yml
+++ b/templates/day0-starter-kit/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+# CUSTOMIZE: Update URL to your project board
+contact_links:
+  - name: Project Board
+    url: https://github.com/users/OWNER/projects/NUMBER
+    about: View the full backlog on GitHub Projects

--- a/templates/day0-starter-kit/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/templates/day0-starter-kit/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["type:feature"]
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      # CUSTOMIZE: Add project-specific areas
+      options:
+        - area:ui
+        - area:auth
+        - area:db
+        - area:dx
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - p0 — critical
+        - p1 — important
+        - p2 — default
+        - p3 — nice to have
+      default: 2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - xs — trivial
+        - s — straightforward
+        - m — medium (default)
+        - l — complex
+        - xl — epic
+      default: 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What should the feature do and why?
+      placeholder: |
+        **Problem:** ...
+        **Solution:** ...
+        **Acceptance criteria:**
+        - [ ] ...
+    validations:
+      required: true

--- a/templates/day0-starter-kit/.github/dependabot.yml
+++ b/templates/day0-starter-kit/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+
+updates:
+  # Frontend (npm)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    # CUSTOMIZE: Group related packages to reduce PR noise
+    groups:
+      react-ecosystem:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-router*"
+          - "@types/react*"
+      toolchain:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+          - "vitest"
+          - "@testing-library/*"
+          - "eslint*"
+          - "typescript*"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/templates/day0-starter-kit/.github/labels.yml
+++ b/templates/day0-starter-kit/.github/labels.yml
@@ -1,0 +1,41 @@
+# Type labels
+- name: "type:feature"
+  color: "0E8A16"
+  description: "New user-facing functionality"
+- name: "type:bug"
+  color: "D73A4A"
+  description: "Something is broken"
+- name: "type:chore"
+  color: "FEF2C0"
+  description: "Refactoring, cleanup, DX improvements"
+- name: "type:infra"
+  color: "D4C5F9"
+  description: "CI/CD, deploy, build, tooling"
+
+# CUSTOMIZE: Add project-specific area labels
+# Area labels
+- name: "area:ui"
+  color: "BFD4F2"
+  description: "Layout, components, styling, mobile"
+- name: "area:auth"
+  color: "E4E669"
+  description: "Login, signup, sessions"
+- name: "area:db"
+  color: "F9C4D2"
+  description: "Database schema, migrations"
+- name: "area:dx"
+  color: "C2E0C6"
+  description: "Developer experience, tooling, scripts"
+
+# Status labels
+- name: "status:idea"
+  color: "EDEDED"
+  description: "Not yet ready — needs more thought"
+
+# Dependency labels (used by Dependabot)
+- name: "dependencies"
+  color: "0366D6"
+  description: "Dependency updates"
+- name: "ci"
+  color: "795548"
+  description: "GitHub Actions / CI dependencies"

--- a/templates/day0-starter-kit/.github/pull_request_template.md
+++ b/templates/day0-starter-kit/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+<!-- 2-4 bullet points: what changed and why -->
+-
+-
+
+## Backlog
+<!-- Link related GitHub Issues using #NNN so they auto-close on merge -->
+- Closes #
+- None
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code quality
+- [ ] CI/CD / tooling
+- [ ] Documentation
+- [ ] Security fix
+
+## Checklist
+
+### Code quality
+- [ ] `npx tsc --noEmit` — no TypeScript errors
+- [ ] `npm run lint` — no ESLint errors
+- [ ] `npm test -- --run` — all tests pass
+- [ ] `npm run build` — production build succeeds
+
+### Security (if auth / DB / env changed)
+- [ ] No secrets committed
+- [ ] RLS still enforced on affected tables
+
+### Documentation
+- [ ] README updated if user-facing behaviour changed
+- [ ] CLAUDE.md updated if conventions changed
+
+---
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/templates/day0-starter-kit/.github/workflows/auto-project.yml
+++ b/templates/day0-starter-kit/.github/workflows/auto-project.yml
@@ -1,0 +1,23 @@
+name: Auto-add to Project
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    name: Add issue to Project board
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+
+    steps:
+      - name: Add to project board
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # CUSTOMIZE: Replace PROJECT_NUMBER and OWNER with your values
+          gh project item-add PROJECT_NUMBER \
+            --owner OWNER \
+            --url "${{ github.event.issue.html_url }}" \
+            --format json || echo "Failed to add — may need a PAT with project scope"

--- a/templates/day0-starter-kit/.github/workflows/branch-name.yml
+++ b/templates/day0-starter-kit/.github/workflows/branch-name.yml
@@ -1,0 +1,31 @@
+name: Branch Name
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  validate:
+    name: Validate branch name
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check branch name convention
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          PATTERN="^(fix|feat|docs|chore|refactor|release)/"
+
+          # Skip Dependabot and renovate branches
+          if [[ "$BRANCH" =~ ^dependabot/ ]] || [[ "$BRANCH" =~ ^renovate/ ]]; then
+            echo "Dependency bot branch — skipping validation"
+            exit 0
+          fi
+
+          if [[ ! "$BRANCH" =~ $PATTERN ]]; then
+            echo "::error::Branch name '$BRANCH' does not match convention."
+            echo ""
+            echo "Branch must start with one of: fix/, feat/, docs/, chore/, refactor/, release/"
+            exit 1
+          fi
+
+          echo "Branch name '$BRANCH' is valid"

--- a/templates/day0-starter-kit/.github/workflows/ci.yml
+++ b/templates/day0-starter-kit/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  frontend:
+    name: Typecheck / Lint / Test / Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test -- --run
+
+      - name: Build
+        run: npm run build

--- a/templates/day0-starter-kit/.github/workflows/label-sync.yml
+++ b/templates/day0-starter-kit/.github/workflows/label-sync.yml
@@ -1,0 +1,24 @@
+name: Sync Labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/labels.yml'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    name: Sync labels from labels.yml
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/day0-starter-kit/.github/workflows/release.yml
+++ b/templates/day0-starter-kit/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version from package.json
+        id: version
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # CUSTOMIZE: Extract release notes from your changelog format
+      - name: Create GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --generate-notes \
+            --target main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/day0-starter-kit/CLAUDE.md
+++ b/templates/day0-starter-kit/CLAUDE.md
@@ -1,0 +1,111 @@
+# [Project Name]
+
+> One-line description of what this project does and who it's for.
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Frontend | |
+| Styling | |
+| Backend/DB | |
+| Hosting | |
+| Package manager | |
+| System deps | Nix (flake.nix) + direnv (.envrc) |
+
+## Architecture Decisions
+
+> Fill these in BEFORE the first feature commit. These prevent 80% of rework.
+
+### Auth Model
+<!-- Choose one and delete the others -->
+- [ ] **Guest-first** — anyone can use the app immediately; sign-in unlocks persistence/sync
+- [ ] **Auth-required** — sign-in required before any functionality
+- [ ] **Hybrid** — some features public, some gated
+
+### Data Flow
+<!-- Choose one and delete the others -->
+- [ ] **API-first** — app fetches data from backend at runtime; seed data for bootstrapping only
+- [ ] **Bundled** — data ships as JSON in the frontend bundle
+- [ ] **Offline-first** — local-first with background sync
+
+### ID Strategy
+<!-- Choose one and delete the others -->
+- [ ] **Deterministic hash** — `sha256(source + type + content)[:12]` — stable across re-imports
+- [ ] **UUID v4** — random, globally unique
+- [ ] **Auto-increment** — DB-managed sequential IDs
+
+### i18n
+<!-- Choose one and delete the others -->
+- [ ] **Yes** — framework: _________, use `t('key')` from first component
+- [ ] **No** — single language: _________
+
+### State Management
+<!-- Choose one and delete the others -->
+- [ ] **Local only** — useState/useReducer, no global store
+- [ ] **Client + sync** — local state with background sync to DB
+- [ ] **Real-time** — live subscriptions (e.g., Supabase Realtime)
+
+## UX Invariants
+
+> Things that must ALWAYS be true. Add project-specific rules here.
+
+- Mobile: all layouts work on 375px+, mobile-first (base styles for mobile, `md:` for desktop)
+- Touch targets: interactive elements at least 44x44px
+- Dark mode: every light-mode color has a `dark:` variant
+- A11y: `aria-label` on all icon-only buttons, `role` on custom widgets, keyboard navigation
+
+## Quality Gates
+
+> Every PR must pass ALL of these before merge.
+
+```bash
+npx tsc --noEmit          # TypeScript strict
+npm run lint              # ESLint (includes jsx-a11y)
+npm test -- --run         # Unit tests
+npm run build             # Production build
+```
+
+## Key Directories
+
+```
+src/components/   — React components by domain
+src/pages/        — Route pages
+src/lib/          — Core logic
+src/hooks/        — Custom hooks
+src/types/        — TypeScript types
+src/data/seed/    — Seed data (JSON)
+```
+
+## Commands
+
+```bash
+npm run dev          # Dev server
+npm run build        # Production build
+npm run test         # Tests
+npm run lint         # Lint
+```
+
+## Anti-Patterns (Do NOT Do These)
+
+- Never use `any` without a comment explaining why
+- Never use inline `style={}` — Tailwind only
+- Never fetch data inside components — use hooks or page components
+- Never commit `.env.local` or files containing secrets
+- Never modify existing migration files — create new ones
+- Never use `export default` — named exports only
+
+## Agents & Skills
+
+| Name | Type | Purpose |
+|------|------|---------|
+| `/commit` | Skill | Branch → PR → review → fix → human approval → merge |
+| `/backlog` | Skill | Manage backlog items |
+| `/release` | Skill | Cut a versioned release |
+| `coder` | Agent | Autonomous dev cycle with checkpoints |
+| `reviewer` | Agent | Read-only code/a11y/security audit |
+
+## Where to Find Detailed Rules
+
+Code conventions and tooling pitfalls: `.claude/rules/` (auto-loaded every session).
+Domain knowledge and patterns: `.claude/references/` (loaded by skills on demand via `globs:`).

--- a/templates/day0-starter-kit/README.md
+++ b/templates/day0-starter-kit/README.md
@@ -1,0 +1,128 @@
+# Day 0 Starter Kit for Claude Code Projects
+
+> Copy this template into your new project root before the first feature commit.
+
+## What's Inside
+
+```
+CLAUDE.md                                — Project constitution (fill in before coding)
+
+.claude/
+  rules/                                 — Auto-loaded every session
+    data-architecture.md                 — ID strategy, data flow, seed format, migrations
+    auth-model.md                        — Guest-first vs auth-required, implementation rules
+    a11y-checklist.md                    — Per-component accessibility requirements + CI setup
+    mobile-first.md                      — 375px base, pre-merge testing checklist
+    security-model.md                    — Secrets, CSP, RLS, rate limiting, input validation
+    shipping-workflow.md                 — Branch → PR → review → merge (design once)
+    github-sync.md                       — Keep .claude/ and .github/ in sync
+    dev-guide-sync.md                    — Update dev guide when skills/agents change
+
+  skills/                                — User-invocable via /command
+    commit/SKILL.md                      — Full ship cycle with human checkpoint
+    backlog/SKILL.md                     — Backlog management (add, list, update, next)
+    release/SKILL.md                     — Versioned releases with changelog
+    retro/SKILL.md                       — Session retrospective + backlog updates
+    scope/SKILL.md                       — Break items into sub-tasks with effort/risk
+    daily/SKILL.md                       — Daily session wrapper (backlog → work → commit → retro)
+    weekly/SKILL.md                      — Weekly review (progress, prioritize, release check)
+    qa-review/SKILL.md                   — Test coverage audit + write missing tests
+    security-review/SKILL.md             — OWASP-aligned security audit
+    update-changelog/SKILL.md            — Changelog entry + version bump
+    some/SKILL.md                        — Social media post generator
+
+  agents/                                — Autonomous multi-step workflows
+    coder.md                             — Autonomous dev cycle with learning filter
+    reviewer.md                          — Read-only code/a11y/security/mobile audit
+    project-review.md                    — 8-dimension project health scored audit
+    spike-research.md                    — Technical deep-dive → structured decision doc
+
+  references/                            — Loaded on-demand via globs: frontmatter
+    example-reference.md                 — Template showing the globs: pattern
+    github-sync-map.md                   — AI ↔ manual path cross-reference table
+    pr-templates.md                      — Standard + release PR body templates
+
+  settings.local.json                    — Pre-approved safe commands
+
+.github/                                 — GitHub automation (manual contributor path)
+  workflows/
+    ci.yml                               — TypeScript + Lint + Test + Build
+    branch-name.yml                      — Validate branch naming convention
+    release.yml                          — Auto-create GitHub Release on version bump
+    label-sync.yml                       — Sync labels.yml to GitHub
+    auto-project.yml                     — Auto-add new issues to Project board
+  ISSUE_TEMPLATE/
+    bug_report.yml                       — Bug report with priority/effort fields
+    feature_request.yml                  — Feature request with acceptance criteria
+    config.yml                           — Disable blank issues, link to project board
+  pull_request_template.md               — PR checklist (code, security, docs)
+  labels.yml                             — Label-as-code (type:*, area:*, status:*)
+  dependabot.yml                         — Weekly grouped dependency updates
+  CODEOWNERS                             — Auto-assign reviewers by path
+```
+
+## How to Use
+
+### 1. Copy into new project
+```bash
+cp -r templates/day0-starter-kit/{CLAUDE.md,.claude,.github} /path/to/new-project/
+```
+
+### 2. Fill in CLAUDE.md (before writing any code)
+- Project name and description
+- Tech stack
+- **Architecture decisions** — auth model, data flow, ID strategy, i18n, state management
+- **UX invariants** — project-specific rules that must always hold
+- Anti-patterns specific to your project
+
+### 3. Customize rules
+- `data-architecture.md` — choose your ID strategy and data flow
+- `auth-model.md` — choose guest-first vs auth-required
+- `security-model.md` — adjust CSP, auth provider, rate limiting approach
+- Delete rules that don't apply to your project
+
+### 4. Wire up skills
+- `/backlog` — set your GitHub Projects number or choose file-based
+- `/commit` — adjust quality gate commands for your stack
+- `/release` — set changelog location and version source of truth
+- `/some` — set your project URL and repo link
+
+### 5. Wire up GitHub
+- `CODEOWNERS` — replace `@OWNER` with your username
+- `auto-project.yml` — replace `PROJECT_NUMBER` and `OWNER`
+- `labels.yml` — add project-specific `area:*` labels
+- `dependabot.yml` — adjust package groupings for your dependencies
+- `ISSUE_TEMPLATE/config.yml` — update project board URL
+
+### 6. Add domain-specific references
+Create `.claude/references/your-domain.md` with `globs:` frontmatter targeting relevant source files. This auto-loads domain knowledge when the AI touches those files.
+
+### 7. Start building!
+
+## Three-Tier Context Loading
+
+This kit uses the same loading strategy proven in DanskPrep:
+
+| Tier | Location | When Loaded | Purpose |
+|------|----------|-------------|---------|
+| 1 | `CLAUDE.md` + `.claude/rules/` | Every session (auto) | Architecture decisions, coding conventions |
+| 2 | `.claude/references/` | When matching files opened (via `globs:`) | Domain knowledge, patterns |
+| 3 | `.claude/skills/` + `.claude/agents/` | On invocation only | Workflows, automation |
+
+## Key Principle: Globs Are the Best Context Engineering
+
+Every reference file should have `globs:` in its YAML frontmatter. This auto-loads the right knowledge at the right time with zero manual effort. Without globs, references are dead weight.
+
+```yaml
+---
+globs:
+  - "src/lib/auth*.ts"
+  - "src/hooks/useAuth*.ts"
+---
+```
+
+## Origin
+
+Extracted from lessons learned building DanskPrep (March 2026).
+Based on analysis of 145 commits, 100 PRs, and 8 releases over 4 days.
+See the full retrospective: `docs/retrospectives/2026-03-04-context-engineering-retrospective.md`


### PR DESCRIPTION
## Summary
- Added timestamped retrospective analyzing 145 commits, 100 PRs, 8 releases — identifies 13 areas where upfront context engineering would have prevented rework
- Created a reusable Day 0 starter kit (40 files) with all project-agnostic patterns extracted from DanskPrep's `.claude/` and `.github/`
- Added 7 backlog items (BL-045 through BL-051) for starter kit gaps still to explore

## What's in the starter kit
- **8 rules**: data-architecture, auth-model, a11y-checklist, mobile-first, security-model, shipping-workflow, github-sync, dev-guide-sync
- **11 skills**: commit, backlog, release, retro, scope, daily, weekly, qa-review, security-review, update-changelog, some
- **4 agents**: coder (with learning filter), reviewer, project-review (8-dim audit), spike-research
- **3 references**: with `globs:` frontmatter for auto-loading
- **Full `.github/`**: CI, branch naming, release, label sync, auto-project, dependabot, issue templates, PR template, CODEOWNERS

## Backlog
- None (docs-only, no issues to close)

## Test plan
- [ ] Docs-only change — no code affected
- [ ] `templates/` directory is self-contained and not imported by the app
- [ ] Retrospective is a standalone markdown document

🤖 Generated with [Claude Code](https://claude.com/claude-code)