### PR TITLE
chore: release v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "danskprep",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/data/seed/changelog.json
+++ b/src/data/seed/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "0.9.0",
+    "date": "2026-03-04",
+    "title": "Adjective Agreement & Build Optimization",
+    "highlights": [
+      "New grammar topic: Adjective Agreement (Adjektivbøjning) — t-form, e-form, base form rules",
+      "Recategorization script to audit and fix exercise topic misclassifications via LLM",
+      "Vercel preview builds now skip for docs-only and scripts-only changes",
+      "Dependency-aware backlog skill with blocked/unblocked scoring"
+    ],
+    "stats": {
+      "exercises": 933,
+      "words": 595,
+      "grammar_topics": 7,
+      "writing_prompts": 14,
+      "speaking_prompts": 11
+    }
+  },
+  {
     "version": "0.8.0",
     "date": "2026-03-04",
     "title": "Content Pipeline & Developer Guide",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '0.8.0'
+export const APP_VERSION = '0.9.0'
 
 // Feature flags
 export const FEATURES = {


### PR DESCRIPTION
## Release v0.9.0 — Adjective Agreement & Build Optimization

### Changes since v0.8.0
- **Content:** New grammar topic — Adjective Agreement (Adjektivbøjning) with 7 rules, 5 tips, 6 common mistakes
- **Tooling:** `scripts/recategorize-exercises.py` — LLM-powered exercise topic audit and correction
- **Infra:** Vercel `ignoreCommand` skips preview builds for non-app changes (docs, scripts, .claude, .github)
- **Infra:** Dependency-aware `/backlog` skill with deps graph and blocked/unblocked scoring
- **Docs:** Context engineering retrospective + Day 0 starter kit templates

### Version sync
- `src/data/seed/changelog.json` → 0.9.0
- `src/lib/constants.ts` → 0.9.0
- `package.json` → 0.9.0

### Stats
| Metric | Count |
|--------|-------|
| Exercises | 933 |
| Words | 595 |
| Grammar topics | 7 (was 6) |
| Writing prompts | 14 |
| Speaking prompts | 11 |

### Verification
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — success
- [x] `npm run test` — 91/91 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)