### PR TITLE
chore: add $schema to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "ignoreCommand": "! git diff HEAD^ HEAD --name-only 2>/dev/null | grep -qE '^(src/|public/|api/|index\\.html|package\\.json|package-lock\\.json|\\.npmrc|vite\\.config\\.ts|tailwind\\.config\\.js|postcss\\.config\\.js|tsconfig|components\\.json|vercel\\.json)' || exit 1"
 }


### PR DESCRIPTION
Adds $schema field for IDE validation. Also triggers Vercel production deploy for v0.9.0 (previous deploy was rate-limited).