### PR TITLE
chore: sync project board status on merge in /commit skill

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -124,6 +124,15 @@ Please review the PR. Reply with:
    git branch -d <branch>
    ```
 6. Verify you're on an up-to-date main: `git log --oneline -3` should show the merge commit
+7. **Update project board** — for each backlog item closed by this PR (`Closes #NNN`), set the project Status to Done:
+   ```bash
+   # Find the project item ID, then set Status=Done
+   gh project item-list 15 --owner YanCheng-go --format json --limit 200 | \
+     python3 -c "import json,sys; [print(i['id']) for i in json.load(sys.stdin)['items'] if i.get('content',{}).get('number')==<issue_number>]"
+   gh project item-edit --project-id PVT_kwHOAtALr84BQs_6 --id <item_id> \
+     --field-id PVTSSF_lAHOAtALr84BQs_6zg-vxHc --single-select-option-id 98236657
+   ```
+   This ensures the project board stays in sync — `Closes #NNN` only closes the issue, not the project field.
 
 **If the merge happened in a previous session** (e.g., merged via GitHub UI), still run step 4-6 to sync before starting new work.
 


### PR DESCRIPTION
## Summary
- The `/commit` skill closed GitHub Issues via `Closes #NNN` on merge, but never updated the GitHub Projects Status field to Done
- This left completed items showing as "In Progress" on the project board (BL-030, BL-035, BL-036, BL-037 were all affected)
- Adds Step 8.7 to `/commit` that sets project Status=Done for each closed backlog item after merge

## Backlog
- None (process fix, no backlog item)

## Test plan
- [ ] Verified by manually updating 4 stale items to Done on the board this session
- [ ] Next `/commit` merge will exercise the new step

🤖 Generated with [Claude Code](https://claude.com/claude-code)